### PR TITLE
Adding automatic clang-format check on push to master

### DIFF
--- a/.github/workflows/test-clang-format.yml
+++ b/.github/workflows/test-clang-format.yml
@@ -1,0 +1,16 @@
+name: test-clang-format
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: DoozyX/clang-format-lint-action@v0.5
+      with:
+        source: '.'
+        exclude: './src/ramulator'
+        extensions: 'h,cpp,cc,c'
+        clangFormatVersion: 5

--- a/docs/system_requirements.md
+++ b/docs/system_requirements.md
@@ -6,7 +6,7 @@
 * gcc 7.3.1
 * McPAT v1.0
 * CACTI 6.5
-* Intel [PIN 3.5](https://software.intel.com/en-us/articles/pin-a-binary-instrumentation-tool-downloads).
+* Intel [PIN 3.5](https://software.intel.com/system/files/managed/23/50/pinplay-drdebug-3.5-pin-3.5-97503-gac534ca30-gcc-linux.tar.gz).
 * Clang 5.0.1
 
 ## Python Packages


### PR DESCRIPTION
Any source code files are checked to ensure that clang-format has been run. If clang-format was not run, the test fails. 