### PR TITLE
Adding testing infrastructure for testing execution-driven pintool.

### DIFF
--- a/src/pin/pin_exec/testing/Makefile
+++ b/src/pin/pin_exec/testing/Makefile
@@ -1,0 +1,33 @@
+COMMON_LIB_DIR = ../../pin_lib
+PIN_EXEC_DIR = ..
+SCARAB_DIR = $(abspath ../../..)
+PIN_EXEC_TOOL_PATH = $(abspath $(PIN_EXEC_DIR)/obj-intel64/rollback.so)
+TEST_BINARY = test_binary
+SIMPLE_LOOP = simple_loop
+
+CC_FLAGS := -lgtest -std=c++14  -I$(SCARAB_DIR) -L $(COMMON_LIB_DIR)/obj -lpin_fe -DPIN_EXEC_TOOL_PATH=\"$(PIN_EXEC_TOOL_PATH)\" -DSIMPLE_LOOP=\"$(SIMPLE_LOOP)\"
+
+ASSEMBLY_SOURCES=$(wildcard *.s)
+CC_SOURCES=$(wildcard *.cc)
+CC_HEADERS=$(wildcard *.h)
+TEST_BINARIES=$(patsubst %.s,%,$(ASSEMBLY_SOURCES))
+
+all: $(TEST_BINARY) $(TEST_BINARIES) pin_exec ## Builds and runs all the unit tests 
+	./$(TEST_BINARY)
+
+%:%.s
+	as -o $@.o $^
+	ld -o $@ $@.o
+	rm $@.o
+
+$(TEST_BINARY): $(CC_SOURCES) $(CC_HEADERS) pin_lib ## Builds the unit test binary
+	g++ $(CC_SOURCES) -o $@ $(CC_FLAGS)
+
+pin_lib:
+	make -C $(COMMON_LIB_DIR)
+
+pin_exec:
+	make -C $(PIN_EXEC_DIR)
+
+clean:
+	rm test_binary

--- a/src/pin/pin_exec/testing/fake_scarab.cc
+++ b/src/pin/pin_exec/testing/fake_scarab.cc
@@ -1,0 +1,91 @@
+#include "fake_scarab.h"
+
+#include <exception>
+#include <sstream>
+
+namespace scarab {
+namespace pin {
+namespace testing {
+
+Fake_Scarab::Fake_Scarab() :
+    tmpdir_path_(get_new_tmpdir_path()),
+    pintool_process_(
+      create_pin_exec_cmd(SIMPLE_LOOP, tmpdir_path_ + "/socket")) {
+  // Socket constructor blocks until it connects to its client(s), so the
+  // pintool process should be started before the socker server is created.
+  pintool_process_.start();
+  server_communicator_ = std::make_unique<Server>(tmpdir_path_ + "/socket",
+                                                  /*num_processes=*/1);
+}
+
+Fake_Scarab::~Fake_Scarab() {
+  if(!tmpdir_path_.empty()) {
+    const auto cmd = std::string("rm -r ") + tmpdir_path_;
+    system(cmd.c_str());
+  }
+}
+
+void Fake_Scarab::execute_and_verify_instructions(
+  const std::vector<uint64_t>& addresses) {
+  for(auto address : addresses) {
+    fetch_new_ops_if_buffer_is_empty();
+    ASSERT_TRUE(CHECK_EQUAL_IN_HEX(cached_cop_buffers.front().instruction_addr,
+                                   address, "instruction address"));
+    retire_latest_op();
+  }
+}
+
+void Fake_Scarab::execute_until_completion() {
+  while(true) {
+    fetch_new_ops_if_buffer_is_empty();
+    if(is_sentinal_op(&cached_cop_buffers.front())) {
+      break;
+    }
+    retire_latest_op();
+  }
+}
+
+bool Fake_Scarab::has_reached_end() {
+  fetch_new_ops_if_buffer_is_empty();
+  return is_sentinal_op(&cached_cop_buffers.front());
+}
+
+void Fake_Scarab::fetch_new_ops() {
+  Scarab_To_Pin_Msg msg;
+  msg.type      = FE_FETCH_OP;
+  msg.inst_addr = 0;
+  msg.inst_uid  = 0;
+
+  server_communicator_->send(0, (Message<Scarab_To_Pin_Msg>)msg);
+  cached_cop_buffers = server_communicator_->receive<ScarabOpBuffer_type>(
+    /*proc_id=*/0);
+
+  num_fetched_instructions += cached_cop_buffers.size();
+}
+
+void Fake_Scarab::fetch_new_ops_if_buffer_is_empty() {
+  if(cached_cop_buffers.empty()) {
+    fetch_new_ops();
+  }
+}
+
+void Fake_Scarab::retire_latest_op() {
+  if(cached_cop_buffers.empty())
+    return;
+
+  const auto inst_uid = cached_cop_buffers.front().inst_uid;
+
+  Scarab_To_Pin_Msg msg;
+  msg.type      = FE_RETIRE;
+  msg.inst_addr = 0;
+  msg.inst_uid  = inst_uid;
+
+  server_communicator_->send(0, (Message<Scarab_To_Pin_Msg>)msg);
+  cached_cop_buffers.pop_front();
+
+  num_retired_instructions += 1;
+}
+
+}  // namespace testing
+}  // namespace pin
+}  // namespace scarab

--- a/src/pin/pin_exec/testing/fake_scarab.h
+++ b/src/pin/pin_exec/testing/fake_scarab.h
@@ -1,0 +1,48 @@
+#ifndef __PIN_PIN_EXEC_TESTING_FAKE_SCARAB_H__
+#define __PIN_PIN_EXEC_TESTING_FAKE_SCARAB_H__
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "gtest/gtest.h"
+#include "utils.h"
+
+#include "../../pin_lib/message_queue_interface_lib.h"
+#include "../../pin_lib/pin_scarab_common_lib.h"
+
+namespace scarab {
+namespace pin {
+namespace testing {
+
+class Fake_Scarab {
+ public:
+  Fake_Scarab();
+  ~Fake_Scarab();
+
+  void execute_and_verify_instructions(const std::vector<uint64_t>& addresses);
+  void execute_until_completion();
+  bool has_reached_end();
+
+  int64_t num_fetched_instructions = 0;
+  int64_t num_retired_instructions = 0;
+
+ private:
+  void fetch_new_ops();
+  void fetch_new_ops_if_buffer_is_empty();
+  void retire_latest_op();
+
+  std::string             tmpdir_path_;
+  Process_Runner          pintool_process_;
+  std::unique_ptr<Server> server_communicator_;
+
+  ScarabOpBuffer_type cached_cop_buffers;
+};
+
+}  // namespace testing
+}  // namespace pin
+}  // namespace scarab
+
+#endif  //__PIN_PIN_EXEC_TESTING_FAKE_SCARAB_H__

--- a/src/pin/pin_exec/testing/main.cc
+++ b/src/pin/pin_exec/testing/main.cc
@@ -1,0 +1,8 @@
+#include "gtest/gtest.h"
+
+#include "utils.h"
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/pin/pin_exec/testing/simple_loop.s
+++ b/src/pin/pin_exec/testing/simple_loop.s
@@ -1,0 +1,29 @@
+.section .text
+.globl _start
+
+// eax: loop variable
+// ecx: counts of odd loop variables
+_start:
+      xor %eax, %eax 
+      xor %ecx, %ecx 
+
+loop:
+      // first, test if loop variable is odd
+      mov %eax, %ebx 
+      and $1, %ebx
+
+      // only increment ecx if eax is odd
+      je  end_loop
+      add $1, %ecx
+
+end_loop: 
+      // loop for 10 iterations
+      add $1, %eax
+      cmp $10, %eax
+      jl loop
+
+      // exit the program
+      xor %edi, %edi
+      mov $231, %eax
+      syscall
+

--- a/src/pin/pin_exec/testing/simple_loop_test.cc
+++ b/src/pin/pin_exec/testing/simple_loop_test.cc
@@ -1,0 +1,110 @@
+/***************************************************************************************
+ * File         : simple_loop_test.cc
+ * Author       : HPS Research Group
+ * Date         : 1/31/2020
+ * Description  :
+ ***************************************************************************************/
+
+#include <algorithm>
+#include <chrono>
+#include <thread>
+
+#include "gtest/gtest.h"
+
+#include "fake_scarab.h"
+#include "utils.h"
+
+using namespace scarab::pin::testing;
+
+class Simple_Loop_Info {
+ public:
+  enum Basic_Block_Id {
+    INIT,
+    LOOP_BODY_CHECK_COND,
+    LOOP_BODY_CONDITIONAL_INCREMENT,
+    LOOP_EXIT_BLOCK,
+    PROGRAM_EXIT,
+    NUM_BASIC_BLOCKS,
+  };
+
+  Simple_Loop_Info(const Parsed_Binary& parsed_binary) :
+      basic_block_opcodes_{
+        {"xor", "xor"},            // INIT
+        {"mov", "and", "je"},      // LOOP_BODY_CHECK_COND
+        {"add"},                   // LOOP_BODY_CONDITIONAL_INCREMENT
+        {"add", "cmp", "jl"},      // LOOP_EXIT_BLOCK
+        {"xor", "mov", "syscall"}  // PROGRAM_EXIT
+      },
+      basic_block_addresses_(
+        verify_binary_and_get_addresses(parsed_binary, basic_block_opcodes_)) {}
+
+  const std::vector<uint64_t>& get_basic_block_addresses(Basic_Block_Id id) {
+    return basic_block_addresses_.at(id);
+  }
+
+ private:
+  static std::vector<std::vector<uint64_t>> verify_binary_and_get_addresses(
+    const Parsed_Binary&                         parsed_binary,
+    const std::vector<std::vector<const char*>>& basic_block_opcodes) {
+    std::vector<std::vector<uint64_t>> basic_block_addresses;
+
+    auto binary_itr = parsed_binary.begin();
+    for(auto& basic_block : basic_block_opcodes) {
+      basic_block_addresses.emplace_back();
+      for(auto& opcode : basic_block) {
+        if(binary_itr == parsed_binary.end()) {
+          throw std::runtime_error(std::string("expected to see instruction ") +
+                                   opcode +
+                                   ", but reached the end of the binary.");
+        }
+        if(binary_itr->second != opcode) {
+          throw std::runtime_error(std::string("expected to see instruction ") +
+                                   opcode + ", but saw " + binary_itr->second +
+                                   " in the binary.");
+        }
+
+        basic_block_addresses.back().push_back(binary_itr->first);
+        ++binary_itr;
+      }
+    }
+
+    return basic_block_addresses;
+  }
+
+  // Holds a vector char strings of the opcodes for each basic block.
+  const std::vector<std::vector<const char*>> basic_block_opcodes_;
+  const std::vector<std::vector<uint64_t>>    basic_block_addresses_;
+};
+
+class Simple_Loop_Test : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    simple_loop_info_ = std::make_unique<Simple_Loop_Info>(
+      get_instructions_in_binary(std::string("./") + SIMPLE_LOOP));
+  }
+  void TearDown() override {}
+
+  std::unique_ptr<Simple_Loop_Info> simple_loop_info_;
+};
+
+TEST_F(Simple_Loop_Test, OnPathExecutesCorrectly) {
+  std::vector<Simple_Loop_Info::Basic_Block_Id> expected_basic_block_ids;
+  expected_basic_block_ids.push_back(Simple_Loop_Info::INIT);
+  for(int i = 0; i < 10; ++i) {
+    expected_basic_block_ids.push_back(Simple_Loop_Info::LOOP_BODY_CHECK_COND);
+    if(i & 1) {
+      expected_basic_block_ids.push_back(
+        Simple_Loop_Info::LOOP_BODY_CONDITIONAL_INCREMENT);
+    }
+    expected_basic_block_ids.push_back(Simple_Loop_Info::LOOP_EXIT_BLOCK);
+  }
+  expected_basic_block_ids.push_back(Simple_Loop_Info::PROGRAM_EXIT);
+
+
+  Fake_Scarab fake_scarab;
+  for(const auto& expected_basic_block_id : expected_basic_block_ids) {
+    ASSERT_NO_FATAL_FAILURE(fake_scarab.execute_and_verify_instructions(
+      simple_loop_info_->get_basic_block_addresses(expected_basic_block_id)));
+  }
+  ASSERT_TRUE(fake_scarab.has_reached_end());
+}

--- a/src/pin/pin_exec/testing/utils.cc
+++ b/src/pin/pin_exec/testing/utils.cc
@@ -1,0 +1,147 @@
+#include "utils.h"
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <array>
+#include <cassert>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <regex>
+#include <sstream>
+#include <vector>
+
+namespace scarab {
+namespace pin {
+namespace testing {
+
+std::string create_pin_exec_cmd(const std::string& binary_path,
+                                const std::string& socket_path) {
+  return std::string(getenv("PIN_ROOT")) + "/pin -t " + PIN_EXEC_TOOL_PATH +
+         " -socket_path " + socket_path + " -- ./" + binary_path;
+}
+
+std::string get_new_tmpdir_path() {
+  char tmpdir_path_template[] = "/tmp/scarab_test_rundir_XXXXXX";
+
+  const auto mkdtemp_ret = mkdtemp(tmpdir_path_template);
+  if(mkdtemp_ret == NULL) {
+    throw std::runtime_error("mkstempt failed with errno: " +
+                             std::to_string(errno));
+  }
+  return tmpdir_path_template;
+}
+
+std::string execute_cmd_and_get_output(const char* command) {
+  std::string                   output;
+  constexpr int                 BUFFER_SIZE = 4096;
+  std::array<char, BUFFER_SIZE> buffer;
+
+  FILE* pipe_fptr = popen(command, "r");
+  if(!pipe_fptr) {
+    throw std::runtime_error(std::string("Could not open a pipe to execute: ") +
+                             command);
+  }
+
+  while(fgets(buffer.data(), BUFFER_SIZE, pipe_fptr) != NULL) {
+    output += buffer.data();
+  }
+
+  pclose(pipe_fptr);
+  return output;
+}
+
+Parsed_Binary get_instructions_in_binary(const std::string& binary_path) {
+  Parsed_Binary parsed_output;
+
+  const auto objdump_cmd = "objdump -d --no-show-raw-insn " + binary_path +
+                           " 2>&1";
+  const auto objdump_output = execute_cmd_and_get_output(objdump_cmd.c_str());
+
+
+  std::istringstream output_stream(objdump_output);
+  std::regex         search_expr("([0-9a-f]+):\\s+([a-z]+)");
+  std::smatch        matches;
+  for(std::string line; std::getline(output_stream, line);) {
+    const auto found_matches = std::regex_search(line, matches, search_expr);
+    if(!found_matches || matches.size() != 3) {
+      continue;
+    }
+
+    parsed_output.emplace_back(strtoul(matches[1].str().c_str(), NULL, 16),
+                               matches[2]);
+  }
+
+  return parsed_output;
+}
+
+void Process_Runner::start() {
+  if(running_) {
+    std::cerr << "start_process() called when a process is already running";
+    return;
+  }
+
+  const auto fork_result = fork();
+  assert(fork_result >= 0);
+  if(fork_result == 0) {
+    execute_cmd();
+  } else {
+    child_pid_ = fork_result;
+  }
+
+  running_ = true;
+}
+
+bool Process_Runner::is_running() {
+  if(running_) {
+    int        status;
+    const auto wait_result = waitpid(child_pid_, &status, WNOHANG);
+    assert(wait_result >= 0);
+    if(wait_result > 0) {
+      if(wait_result != child_pid_) {
+        std::cout << "waitpid() returned a different pid (" << wait_result
+                  << ") from the child pid (" << child_pid_ << ")";
+        assert(false);
+      }
+      if(WIFEXITED(status) || WIFSIGNALED(status)) {
+        running_ = false;
+      }
+    }
+  }
+
+  return running_;
+}
+
+void Process_Runner::stop() {
+  if(!running_)
+    return;
+
+  kill(child_pid_, SIGTERM);
+  wait(NULL);
+  running_ = false;
+}
+
+void Process_Runner::execute_cmd() {
+  const auto array_size = run_cmd_.size() + 1;
+  auto       argv_array = std::make_unique<char[]>(array_size);
+  memcpy(argv_array.get(), run_cmd_.c_str(), array_size);
+  std::vector<char*> argv_ptrs;
+
+  char* next_token = strtok(argv_array.get(), " ");
+  argv_ptrs.push_back(next_token);
+  while(next_token != NULL) {
+    next_token = strtok(NULL, " ");
+    argv_ptrs.push_back(next_token);
+  }
+
+  execv(argv_ptrs[0], argv_ptrs.data());
+
+  throw std::runtime_error("Command could not be executed properly: " +
+                           run_cmd_);
+}
+
+}  // namespace testing
+}  // namespace pin
+}  // namespace scarab

--- a/src/pin/pin_exec/testing/utils.h
+++ b/src/pin/pin_exec/testing/utils.h
@@ -1,0 +1,83 @@
+#ifndef __PIN_PIN_EXEC_TESTING_UTILS_H__
+#define __PIN_PIN_EXEC_TESTING_UTILS_H__
+
+#include <sys/types.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace scarab {
+namespace pin {
+namespace testing {
+
+// Representation of the parsed binary.
+using Parsed_Binary = std::vector<std::pair<uint64_t, std::string>>;
+
+// Creates a command for executing a pin_exec pintool process for the given
+// arguments.
+std::string create_pin_exec_cmd(const std::string& binary_path,
+                                const std::string& socket_path);
+
+// Creates a new temporary directory and returns its path. The directory is
+// guaranteed to be new through Linux API.
+std::string get_new_tmpdir_path();
+
+
+// Executes command and returns its stdout as a string.
+// Hint: you can use "2>&1" to redirect stderr to stdout as part of the command.
+std::string execute_cmd_and_get_output(const char* command);
+
+// Uses Linux objdump to get a list of PC-Opcode pairs in the binary.
+Parsed_Binary get_instructions_in_binary(const std::string& binary_path);
+
+template <typename T>
+::testing::AssertionResult CHECK_EQUAL_IN_HEX(
+  T actual, T expected, const std::string& variable_name = {}) {
+  static_assert(std::is_integral<T>::value,
+                "T should be an integral (integer) type");
+  if(actual == expected) {
+    return ::testing::AssertionSuccess();
+  } else {
+    ::testing::Message msg;
+    if(!variable_name.empty()) {
+      msg << "Mismatch in Variable " << variable_name << ".";
+    }
+    msg << "Actual: " << std::hex << actual << ".";
+    msg << "Expected: " << std::hex << expected << ".";
+    return ::testing::AssertionFailure(msg);
+  }
+}
+
+// A class for asynchronously running a Linux command through a forked process.
+class Process_Runner {
+ public:
+  Process_Runner(const std::string& run_cmd) : run_cmd_(run_cmd) {}
+  ~Process_Runner() { stop(); }
+
+  // If the process in not running, forks a new process and runs the command in
+  // the child process.
+  void start();
+
+  // Probes whether the process is running.
+  bool is_running();
+
+  // Kills the child process.
+  void stop();
+
+ private:
+  void execute_cmd();
+
+  std::string run_cmd_;
+  pid_t       child_pid_;
+  bool        running_ = false;
+};
+
+
+}  // namespace testing
+}  // namespace pin
+}  // namespace scarab
+
+#endif  //__PIN_PIN_EXEC_TESTING_UTILS_H__

--- a/src/pin/pin_lib/message_queue_interface_lib.cc
+++ b/src/pin/pin_lib/message_queue_interface_lib.cc
@@ -398,10 +398,20 @@ void Client::disconnect() {
 }
 
 void Client::connect_to_server() {
-  int32_t failure = connect(socket_fd, (struct sockaddr*)&socket_address,
-                            socket_address_length);
-  // unlink(socket_fd);
-  CHECK_FOR_FAILURE(failure < 0, "Connection to Server Failed");
+  constexpr int WAIT_PERIOD_IN_USECONDS = 100000;  // Retry after 100ms
+  constexpr int NUM_TRIALS              = 100;     // Total trail time = 10s
+
+  for(int i = 0; i < NUM_TRIALS; ++i) {
+    if(connect(socket_fd, (struct sockaddr*)&socket_address,
+               socket_address_length) == 0) {
+      return;
+    }
+
+    printf("Connected to Server failed. Trying again after %d ms",
+           WAIT_PERIOD_IN_USECONDS / 1000);
+    usleep(WAIT_PERIOD_IN_USECONDS);
+  }
+  CHECK_FOR_FAILURE(true, "Connection to Server Failed");
 }
 
 void Client::verify_server_connection() {


### PR DESCRIPTION
Using gtest for testing infrastructure. Some aspects of the test environment are flimsy, e.g., the tests may hang without timeout if the environment is not set up properly. Currently only testing on-path behavior without redirection.