### PR TITLE
More pin_exec tests for wrongpath NOP mode

### DIFF
--- a/src/pin/pin_exec/testing/.gitignore
+++ b/src/pin/pin_exec/testing/.gitignore
@@ -1,5 +1,7 @@
+nop_mode_bad_store
 nop_mode_nonret_direct
 nop_mode_nonret_indirect
+nop_mode_not_taken
 nop_mode_ret
 simple_loop
 test_binary

--- a/src/pin/pin_exec/testing/Makefile
+++ b/src/pin/pin_exec/testing/Makefile
@@ -7,6 +7,8 @@ SIMPLE_LOOP_BINARY = $(abspath ./simple_loop)
 NOP_MODE_RET_BINARY = $(abspath ./nop_mode_ret)
 NOP_MODE_NONRET_DIRECT_BINARY = $(abspath ./nop_mode_nonret_direct)
 NOP_MODE_NONRET_INDIRECT_BINARY = $(abspath ./nop_mode_nonret_indirect)
+NOP_MODE_NOT_TAKEN_BINARY = $(abspath ./nop_mode_not_taken)
+NOP_MODE_BAD_STORE_BINARY = $(abspath ./nop_mode_bad_store)
 
 CC_FLAGS := -lgtest -lpthread -std=c++14  -I$(SCARAB_DIR) 
 CC_FLAGS += -L $(COMMON_LIB_DIR)/obj -lpin_fe
@@ -15,6 +17,8 @@ CC_FLAGS += -DSIMPLE_LOOP_BINARY=\"$(SIMPLE_LOOP_BINARY)\"
 CC_FLAGS += -DNOP_MODE_RET_BINARY=\"$(NOP_MODE_RET_BINARY)\"
 CC_FLAGS += -DNOP_MODE_NONRET_DIRECT_BINARY=\"$(NOP_MODE_NONRET_DIRECT_BINARY)\"
 CC_FLAGS += -DNOP_MODE_NONRET_INDIRECT_BINARY=\"$(NOP_MODE_NONRET_INDIRECT_BINARY)\"
+CC_FLAGS += -DNOP_MODE_NOT_TAKEN_BINARY=\"$(NOP_MODE_NOT_TAKEN_BINARY)\"
+CC_FLAGS += -DNOP_MODE_BAD_STORE_BINARY=\"$(NOP_MODE_BAD_STORE_BINARY)\"
 
 ASSEMBLY_SOURCES=$(wildcard *.s)
 CC_SOURCES=$(wildcard *.cc)

--- a/src/pin/pin_exec/testing/fake_scarab.cc
+++ b/src/pin/pin_exec/testing/fake_scarab.cc
@@ -35,14 +35,14 @@ void Fake_Scarab::fetch_instructions(const std::vector<uint64_t>& addresses) {
 }
 
 void Fake_Scarab::fetch_instructions_in_wrongpath_nop_mode(
-  uint64_t next_fetch_addr, int num_instrucitons,
-  Wrongpath_Nop_Mode_Reason reason) {
-  for(int i = 0; i < num_instrucitons; ++i) {
+  uint64_t next_fetch_addr, int num_instructions,
+  Wrongpath_Nop_Mode_Reason expected_reason) {
+  for(int i = 0; i < num_instructions; ++i) {
     fetch_next_instruction();
     ASSERT_TRUE(CHECK_EQUAL_IN_HEX(fetched_ops_.back().instruction_addr,
                                    next_fetch_addr, "instruction address"));
     ASSERT_TRUE(fetched_ops_.back().fake_inst);
-    ASSERT_EQ(fetched_ops_.back().fake_inst_reason, reason);
+    ASSERT_EQ(fetched_ops_.back().fake_inst_reason, expected_reason);
 
     next_fetch_addr += 1;
   }
@@ -59,6 +59,20 @@ void Fake_Scarab::fetch_until_first_control_flow() {
     ASSERT_FALSE(has_reached_end());
     fetch_next_instruction();
   } while(fetched_ops_.back().cf_type == 0);
+}
+
+void Fake_Scarab::fetch_until_first_wrongpath_nop_mode(
+  int max_num_instructions, Wrongpath_Nop_Mode_Reason expected_reason) {
+  for(int i = 0; i < max_num_instructions; ++i) {
+    fetch_next_instruction();
+
+    if(fetched_ops_.back().fake_inst) {
+      ASSERT_EQ(fetched_ops_.back().fake_inst_reason, expected_reason);
+      return;
+    }
+  }
+
+  GTEST_FATAL_FAILURE_("Did not go to wrongpath nop mode");
 }
 
 uint64_t Fake_Scarab::get_latest_inst_uid() {

--- a/src/pin/pin_exec/testing/fake_scarab.h
+++ b/src/pin/pin_exec/testing/fake_scarab.h
@@ -26,12 +26,15 @@ class Fake_Scarab {
   void fetch_instructions(const std::vector<uint64_t>& addresses);
 
   void fetch_instructions_in_wrongpath_nop_mode(
-    uint64_t next_fetch_addr, int num_instrucitons,
-    Wrongpath_Nop_Mode_Reason reason);
+    uint64_t next_fetch_addr, int num_instructions,
+    Wrongpath_Nop_Mode_Reason expected_reason);
 
   void fetch_until_completion();
 
   void fetch_until_first_control_flow();
+
+  void fetch_until_first_wrongpath_nop_mode(
+    int max_num_instructions, Wrongpath_Nop_Mode_Reason expected_reason);
 
   uint64_t get_latest_inst_uid();
 

--- a/src/pin/pin_exec/testing/nop_mode_bad_store.s
+++ b/src/pin/pin_exec/testing/nop_mode_bad_store.s
@@ -1,0 +1,18 @@
+.section .text
+.globl _start
+
+_start:
+      lea gvar, %rax
+      movq $1, (%rax)
+      mov %rsp, %rax # since we do not write anything to the stack in this
+                     # program, writing to the stack on the wrong path should
+                     # trigger wrong path nop mode
+      sub $8, %rsp
+      jmp done       # redirect this to the first mov
+done:
+      xor %rdi, %rdi
+      mov $231, %rax
+      syscall
+
+.section .data
+gvar: .skip 8, 0

--- a/src/pin/pin_exec/testing/nop_mode_not_taken.s
+++ b/src/pin/pin_exec/testing/nop_mode_not_taken.s
@@ -1,0 +1,28 @@
+.section .text
+.globl _start
+
+_start:
+      mov $2, %rax
+loop:
+      sub $1, %rax
+      jne skip
+      xor %rdi, %rdi
+      mov $231, %rax
+      syscall
+skip: 
+      jne loop # this branch should be redirected to fall thrugh, then
+               # eventually the process reaches non-instrumented instructions
+               # on the wrongpath.
+      sub $1, %rax
+      jne skip
+      jne skip
+      jne skip
+      jne skip
+      jne skip
+      jne skip
+      jne skip
+loop2:
+      jmp loop2
+
+      
+

--- a/src/pin/pin_exec/testing/nop_mode_tests.cc
+++ b/src/pin/pin_exec/testing/nop_mode_tests.cc
@@ -24,6 +24,14 @@
 #define NOP_MODE_NONRET_INDIRECT_BINARY "./nop_mode_nonret_indirect"
 #endif
 
+#ifndef NOP_MODE_NOT_TAKEN_BINARY
+#define NOP_MODE_NOT_TAKEN_BINARY "./nop_mode_not_taken"
+#endif
+
+#ifndef NOP_MODE_BAD_STORE_BINARY
+#define NOP_MODE_BAD_STORE_BINARY "./nop_mode_bad_store"
+#endif
+
 using namespace scarab::pin::testing;
 
 class Nop_Mode_Binary_Info {
@@ -93,6 +101,26 @@ class Nop_Mode_Nonret_Indirect_Binary_Info : public Nop_Mode_Binary_Info {
   const uint64_t far_target_addr;
 };
 
+class Nop_Mode_Not_Taken_Binary_Info : public Nop_Mode_Binary_Info {
+ public:
+  Nop_Mode_Not_Taken_Binary_Info() :
+      Nop_Mode_Binary_Info(NOP_MODE_NOT_TAKEN_BINARY),
+      redirect_addr(find_addr("sub", 2)) {}
+
+  const uint64_t redirect_addr;
+};
+
+class Nop_Mode_Bad_Store_Binary_Info : public Nop_Mode_Binary_Info {
+ public:
+  Nop_Mode_Bad_Store_Binary_Info() :
+      Nop_Mode_Binary_Info(NOP_MODE_BAD_STORE_BINARY),
+      redirect_addr(find_addr("movq")),
+      instruction_after_store(find_addr("mov")) {}
+
+  const uint64_t redirect_addr;
+  const uint64_t instruction_after_store;
+};
+
 TEST(RET_NOP_MODE, ReturningToUntracedAddressTriggersNopMode) {
   Nop_Mode_Ret_Binary_Info binary_info;
   Fake_Scarab              fake_scarab(NOP_MODE_RET_BINARY);
@@ -158,6 +186,51 @@ TEST(RET_NOP_MODE, IndirectJumpingToUntracedAddressTriggersNopMode) {
   ASSERT_NO_FATAL_FAILURE(fake_scarab.fetch_instructions_in_wrongpath_nop_mode(
     binary_info.far_target_addr, 10,
     WPNM_REASON_NONRET_CF_TO_NOT_INSTRUMENTED));
+
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.recover(redirect_uid));
+
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.fetch_until_completion());
+  ASSERT_TRUE(fake_scarab.has_reached_end());
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.retire_all());
+}
+
+TEST(RET_NOP_MODE, FallThroughToUntracedAddressTriggersNopMode) {
+  Nop_Mode_Not_Taken_Binary_Info binary_info;
+
+  Fake_Scarab fake_scarab(NOP_MODE_NOT_TAKEN_BINARY);
+
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.fetch_until_first_control_flow());
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.fetch_until_first_control_flow());
+
+  const auto redirect_uid  = fake_scarab.get_latest_inst_uid();
+  const auto redirect_addr = binary_info.redirect_addr;
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.redirect(redirect_addr));
+
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.fetch_until_first_wrongpath_nop_mode(
+    10, WPNM_REASON_NOT_TAKEN_TO_NOT_INSTRUMENTED));
+
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.recover(redirect_uid));
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.fetch_until_completion());
+  ASSERT_TRUE(fake_scarab.has_reached_end());
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.retire_all());
+}
+
+TEST(RET_NOP_MODE, StoreToUnseenAddressTriggersNopMode) {
+  Nop_Mode_Bad_Store_Binary_Info binary_info;
+
+  Fake_Scarab fake_scarab(NOP_MODE_BAD_STORE_BINARY);
+
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.fetch_until_first_control_flow());
+
+  const auto redirect_uid  = fake_scarab.get_latest_inst_uid();
+  const auto redirect_addr = binary_info.redirect_addr;
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.redirect(redirect_addr));
+
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.fetch_instructions({redirect_addr}));
+
+  ASSERT_NO_FATAL_FAILURE(fake_scarab.fetch_instructions_in_wrongpath_nop_mode(
+    binary_info.instruction_after_store, 10,
+    WPNM_REASON_WRONG_PATH_STORE_TO_NEW_REGION));
 
   ASSERT_NO_FATAL_FAILURE(fake_scarab.recover(redirect_uid));
 


### PR DESCRIPTION
- triggering wrongpath nop mode with uninstrumented fall-through paths
- triggering wrongpath nop mode with writes to new writable memory regions