### PR TITLE
Two small fixes to message queue interface.

### DIFF
--- a/src/pin/pin_lib/message_queue_interface_lib.cc
+++ b/src/pin/pin_lib/message_queue_interface_lib.cc
@@ -407,7 +407,7 @@ void Client::connect_to_server() {
       return;
     }
 
-    printf("Connected to Server failed. Trying again after %d ms",
+    printf("Connected to Server failed. Trying again after %d ms\n",
            WAIT_PERIOD_IN_USECONDS / 1000);
     usleep(WAIT_PERIOD_IN_USECONDS);
   }

--- a/src/pin/pin_lib/message_queue_interface_lib.h
+++ b/src/pin/pin_lib/message_queue_interface_lib.h
@@ -177,7 +177,7 @@ Message<std::vector<T>>::operator std::vector<T>() const {
   for(uint32_t i = 0; i < size_of_vector; ++i) {
     uint32_t start_idx = i * sizeof(T);
     uint32_t stop_idx  = (i + 1) * sizeof(T);
-    std::copy(&data[start_idx], &data[stop_idx], &object[i]);
+    std::copy(&data[start_idx], &data[stop_idx], (char*)&object[i]);
   }
   return object;
 }


### PR DESCRIPTION
-Print statement needed newline
-Pointer value needs to be cast to char, otherwise copy will not happen correctly