### PR TITLE
Adding some fixes for multicore runs:

### DIFF
--- a/src/PARAMS.kaby_lake
+++ b/src/PARAMS.kaby_lake
@@ -127,7 +127,9 @@
 
 ### Prefetcher
 --pref_framework_on             1
---pref_stream_on 		1
+--pref_stream_on 		            1
+--pref_stream_per_core_enable   1
+--pref_shared_queues            0
 --pref_train_on_pref_misses     0
 --pref_oracle_train             0
 --pref_ul1req_queue_overwrite_on_full 1

--- a/src/bp/tagescl.cc
+++ b/src/bp/tagescl.cc
@@ -67,9 +67,13 @@ Branch_Type get_branch_type(uns proc_id, Cf_Type cf_type) {
 }  // end of anonymous namespace
 
 void bp_tagescl_init() {
-  for(uns i = 0; i < NUM_CORES; ++i) {
-    tagescl_predictors.emplace_back(NODE_TABLE_SIZE);
+  if(tagescl_predictors.size() == 0) {
+    tagescl_predictors.reserve(NUM_CORES);
+    for(uns i = 0; i < NUM_CORES; ++i) {
+      tagescl_predictors.emplace_back(NODE_TABLE_SIZE);
+    }
   }
+  ASSERTM(0, tagescl_predictors.size() == NUM_CORES, "tagescl_predictors not initialized correctly");
 }
 
 void bp_tagescl_timestamp(Op* op) {

--- a/src/bp/tagescl.cc
+++ b/src/bp/tagescl.cc
@@ -73,7 +73,8 @@ void bp_tagescl_init() {
       tagescl_predictors.emplace_back(NODE_TABLE_SIZE);
     }
   }
-  ASSERTM(0, tagescl_predictors.size() == NUM_CORES, "tagescl_predictors not initialized correctly");
+  ASSERTM(0, tagescl_predictors.size() == NUM_CORES,
+          "tagescl_predictors not initialized correctly");
 }
 
 void bp_tagescl_timestamp(Op* op) {

--- a/src/frontend/pin_exec_driven_fe.cc
+++ b/src/frontend/pin_exec_driven_fe.cc
@@ -146,7 +146,7 @@ void pin_exec_driven_redirect(uns proc_id, uns64 inst_uid, Addr fetch_addr) {
    * finish. Processes will synchronize when Scarab sends next command to PIN*/
   Scarab_To_Pin_Msg msg;
   msg.type      = FE_REDIRECT;
-  msg.inst_addr = convert_to_cmp_addr(0, fetch_addr); // removing proc_id
+  msg.inst_addr = convert_to_cmp_addr(0, fetch_addr);  // removing proc_id
   msg.inst_uid  = inst_uid;
   uop_generator_recover(proc_id);
 

--- a/src/frontend/pin_exec_driven_fe.cc
+++ b/src/frontend/pin_exec_driven_fe.cc
@@ -146,7 +146,7 @@ void pin_exec_driven_redirect(uns proc_id, uns64 inst_uid, Addr fetch_addr) {
    * finish. Processes will synchronize when Scarab sends next command to PIN*/
   Scarab_To_Pin_Msg msg;
   msg.type      = FE_REDIRECT;
-  msg.inst_addr = fetch_addr;
+  msg.inst_addr = convert_to_cmp_addr(0, fetch_addr); // removing proc_id
   msg.inst_uid  = inst_uid;
   uop_generator_recover(proc_id);
 

--- a/src/ramulator.cc
+++ b/src/ramulator.cc
@@ -173,8 +173,8 @@ int ramulator_send(Mem_Req* scarab_req) {
 
   auto it_scarab_req = inflight_read_reqs.find(req.addr);
   if(it_scarab_req != inflight_read_reqs.end()) {
-    DEBUG(0, "Ramulator: Duplicate (%s) request to address %llu\n",
-          Mem_Req_Type_str(scarab_req->type), scarab_req->addr);
+    DEBUG(scarab_req->proc_id, "Ramulator: Duplicate (%s) request to address %llx\n",
+        Mem_Req_Type_str(scarab_req->type), scarab_req->addr);
 
     if(req.type == Request::Type::READ)
       inflight_read_reqs[req.addr].push_back(
@@ -202,9 +202,9 @@ int ramulator_send(Mem_Req* scarab_req) {
   }
 
   if(is_sent) {
-    DEBUG(0, "Ramulator: The request has been enqueued.\n");
+    DEBUG(scarab_req->proc_id, "Ramulator: The request has been enqueued.\n");
   } else {
-    DEBUG(0, "Ramulator: The request has been rejected. Queue full?\n");
+    DEBUG(scarab_req->proc_id, "Ramulator: The request has been rejected. Queue full?\n");
   }
 
   return (int)is_sent;
@@ -229,8 +229,9 @@ void enqueue_response(Request& req) {
 
 bool try_completing_request(Mem_Req* req) {
   if((unsigned int)mem->l1fill_queue.entry_count < MEM_L1_FILL_QUEUE_ENTRIES) {
-    DEBUG(0, "Ramulator: Completing a (%s) request to address %llu\n",
+    DEBUG(req->proc_id, "Ramulator: Completing a (%s) request to address %llx\n",
           Mem_Req_Type_str(req->type), req->addr);
+
     mem_complete_bus_in_access(
       req, 0 /*mem->mem_queue.base[ii].priority*/);  // TODO_hasan: how do we
                                                      // need to set the

--- a/src/ramulator.cc
+++ b/src/ramulator.cc
@@ -173,8 +173,9 @@ int ramulator_send(Mem_Req* scarab_req) {
 
   auto it_scarab_req = inflight_read_reqs.find(req.addr);
   if(it_scarab_req != inflight_read_reqs.end()) {
-    DEBUG(scarab_req->proc_id, "Ramulator: Duplicate (%s) request to address %llx\n",
-        Mem_Req_Type_str(scarab_req->type), scarab_req->addr);
+    DEBUG(scarab_req->proc_id,
+          "Ramulator: Duplicate (%s) request to address %llx\n",
+          Mem_Req_Type_str(scarab_req->type), scarab_req->addr);
 
     if(req.type == Request::Type::READ)
       inflight_read_reqs[req.addr].push_back(
@@ -204,7 +205,8 @@ int ramulator_send(Mem_Req* scarab_req) {
   if(is_sent) {
     DEBUG(scarab_req->proc_id, "Ramulator: The request has been enqueued.\n");
   } else {
-    DEBUG(scarab_req->proc_id, "Ramulator: The request has been rejected. Queue full?\n");
+    DEBUG(scarab_req->proc_id,
+          "Ramulator: The request has been rejected. Queue full?\n");
   }
 
   return (int)is_sent;
@@ -229,7 +231,8 @@ void enqueue_response(Request& req) {
 
 bool try_completing_request(Mem_Req* req) {
   if((unsigned int)mem->l1fill_queue.entry_count < MEM_L1_FILL_QUEUE_ENTRIES) {
-    DEBUG(req->proc_id, "Ramulator: Completing a (%s) request to address %llx\n",
+    DEBUG(req->proc_id,
+          "Ramulator: Completing a (%s) request to address %llx\n",
           Mem_Req_Type_str(req->type), req->addr);
 
     mem_complete_bus_in_access(


### PR DESCRIPTION
1. fixing the init function of the tagescl bps that was causing segfault.
2. removing the proc_id from fetch_addr before sending it to pin at redirect.
3. modifying two knobs related to stream prefetcher in PARAMS.kaby_lake. The default setting causes unfairnerss in multicore runs.