### PR TITLE
made buffer between PIN and Scarab bigger

### DIFF
--- a/src/ctype_pin_inst.h
+++ b/src/ctype_pin_inst.h
@@ -34,8 +34,8 @@
 #define MAX_SRC_REGS_NUM 8
 #define MAX_DST_REGS_NUM 8
 #define MAX_MEM_ADDR_REGS_NUM 2
-#define MAX_LD_NUM 16
-#define MAX_ST_NUM 16
+#define MAX_LD_NUM 8
+#define MAX_ST_NUM 8
 
 typedef uint8_t compressed_reg_t;
 

--- a/src/pin/pin_exec/pin_exec.cpp
+++ b/src/pin/pin_exec/pin_exec.cpp
@@ -63,7 +63,7 @@ KNOB<UINT32> KnobCoreId(KNOB_MODE_WRITEONCE, "pintool", "core_id", "0",
                         "The ID of the Scarab core to connect to");
 
 KNOB<UINT32> KnobMaxBufferSize(
-  KNOB_MODE_WRITEONCE, "pintool", "max_buffer_size", "8",
+  KNOB_MODE_WRITEONCE, "pintool", "max_buffer_size", "16",
   "pintool buffers up to (max_buffer_size-2) instructions for sending");
 
 KNOB<UINT64> KnobHyperFastForwardCount(


### PR DESCRIPTION
Since our checkpoints right now don't actually use AVX512 instructions, we don't need to support 16 reads/writes per instruction, as only 8 will suffice. Hence, we can make the buffer between PIN and Scarab bigger