### PR TITLE
smaller changes to PARAMS.kaby_lake to remove a redundant line, and a…

### DIFF
--- a/src/PARAMS.kaby_lake
+++ b/src/PARAMS.kaby_lake
@@ -164,6 +164,7 @@
 --mem_priority_wb_nodirty    5
 
 --mem_req_buffer_entries        32
+--mem_l1_fill_queue_entries     32
 --memory_interleave_factor      4096
 --bus_width_in_bytes            8
 
@@ -219,7 +220,6 @@
 ####################################
 --set_off_path_confirmed        1
 
---fetch_off_path_ops            1
 --order_beyond_bus              1
 
 --mem_ooo_stores                1


### PR DESCRIPTION
…dd the --mem_l1_fill_queue_entries parameter explicitly