### PR TITLE
added the RAMULATOR_USE_REST_OF_ADDR_AS_ROW_ADDR option that will pre…

### DIFF
--- a/src/ramulator.cc
+++ b/src/ramulator.cc
@@ -134,6 +134,8 @@ void init_configs() {
 
   configs->add("record_cmd_trace", RAMULATOR_REC_CMD_TRACE);
   configs->add("print_cmd_trace", RAMULATOR_PRINT_CMD_TRACE);
+  configs->add("use_rest_of_addr_as_row_addr",
+               RAMULATOR_USE_REST_OF_ADDR_AS_ROW_ADDR);
 
   configs->add("scheduling_policy", RAMULATOR_SCHEDULING_POLICY);
   configs->add("readq_entries", to_string(RAMULATOR_READQ_ENTRIES));

--- a/src/ramulator.param.def
+++ b/src/ramulator.param.def
@@ -70,8 +70,12 @@ DEF_PARAM(ramulator_readq_entries        , RAMULATOR_READQ_ENTRIES              
 DEF_PARAM(ramulator_writeq_entries       , RAMULATOR_WRITEQ_ENTRIES                , uns     , uns    , 32                   , ) 
 
 // Misc.
-DEF_PARAM(ramulator_record_cmd_trace     , RAMULATOR_REC_CMD_TRACE                 , char*   , string , "false"              , )
-DEF_PARAM(ramulator_print_cmd_trace      , RAMULATOR_PRINT_CMD_TRACE               , char*   , string , "false"              , )
+DEF_PARAM(ramulator_record_cmd_trace     , RAMULATOR_REC_CMD_TRACE                 , char*   , string , "off"              , )
+DEF_PARAM(ramulator_print_cmd_trace      , RAMULATOR_PRINT_CMD_TRACE               , char*   , string , "off"              , )
+// make sure that we never artificially introduce aliasing between two phys addrs in Ramulator by making sure we subsume
+// every single phys addr bit in the DRAM address. All phys addrs bits not included as a channel/rank/bank group/bank/column bit
+// will be included as a row bit
+DEF_PARAM(ramulator_use_rest_of_addr_as_row_addr, RAMULATOR_USE_REST_OF_ADDR_AS_ROW_ADDR  , char*   , string , "on"      , )
 
 // Timing parameters (TODO: make these optional. If not specified, present // values defined by RAMULATOR_SPEED should be used instead.)
 DEF_PARAM(ramulator_tCK                  , RAMULATOR_TCK                           , uns     , uns    , 833333               , ) //in femtosecs

--- a/src/ramulator/Config.h
+++ b/src/ramulator/Config.h
@@ -70,6 +70,7 @@ private:
         // Other
         {"record_cmd_trace", "off"},
         {"print_cmd_trace", "off"},
+        {"use_rest_of_addr_as_row_addr", "on"}
     };
 
 	template<typename T>
@@ -190,6 +191,15 @@ public:
       // the default value is false
       if (options.find("print_cmd_trace") != options.end()) {
         if ((options.find("print_cmd_trace"))->second == "on") {
+          return true;
+        }
+        return false;
+      }
+      return false;
+    }
+    bool use_rest_of_addr_as_row_addr() const {
+      if (options.find("use_rest_of_addr_as_row_addr") != options.end()) {
+        if ((options.find("use_rest_of_addr_as_row_addr"))->second == "on") {
           return true;
         }
         return false;


### PR DESCRIPTION
…vent two distinct phys addrs from aliasing in Ramulator

- if RAMULATOR_USE_REST_OF_ADDR_AS_ROW_ADDR is enabled, the row addr will contain all the leftover unused bits in the phys addr. This may be more bits than the number of rows addr bits in the DRAM device, but from a timing model perspective we don't really care