### PR TITLE
Add missing header file to model.h

### DIFF
--- a/src/model.h
+++ b/src/model.h
@@ -30,6 +30,7 @@
 #define __MODEL_H__
 
 #include "globals/global_types.h"
+#include "packet_build.h"
 
 
 /**************************************************************************************/


### PR DESCRIPTION
model.h depends on packet_build.h, however this header was not included.