### PR TITLE
Refactoring tagescl: making history its own object

### DIFF
--- a/src/bp/template_lib/tage.h
+++ b/src/bp/template_lib/tage.h
@@ -229,15 +229,89 @@ struct Tage_Prediction_Info {
   int64_t path_history_checkpoint;
 };
 
+template <class TAGE_HISTORIES_CONFIG>
+class Tage_Histories {
+  public:
+   Tage_Histories(int max_in_flight_branches) :
+       history_register_(max_in_flight_branches) {
+     path_history_ = 0;
+     intialize_folded_history();
+   }
+
+   void push_into_history(
+     uint64_t br_pc, uint64_t br_target, Branch_Type br_type, bool branch_dir,
+     Tage_Prediction_Info<TAGE_HISTORIES_CONFIG>* prediction_info) {
+     head_old_           = history_register_.head_idx();
+     int num_bit_inserts = 2;
+     if(br_type.is_indirect && !br_type.is_conditional) {
+       num_bit_inserts = 3;
+     }
+
+     int pc_dir_hash = ((br_pc ^ (br_pc >> 2))) ^ branch_dir;
+     int path_hash   = br_pc ^ (br_pc >> 2) ^ (br_pc >> 4);
+     if((br_type.is_indirect && br_type.is_conditional) & branch_dir) {
+       pc_dir_hash = (pc_dir_hash ^ (br_target >> 2));
+       path_hash   = path_hash ^ (br_target >> 2) ^ (br_target >> 4);
+     }
+
+     prediction_info->num_global_history_bits = num_bit_inserts;
+     prediction_info->path_history_checkpoint = path_history_;
+     prediction_info->global_history_head_checkpoint_ =
+       history_register_.head_idx();
+
+     for(int i = 0; i < num_bit_inserts; ++i) {
+       history_register_.push_bit(pc_dir_hash & 1);
+       pc_dir_hash >>= 1;
+
+       path_history_ = (path_history_ << 1) ^ (path_hash & 127);
+       path_hash >>= 1;
+
+       for(int j = 0; j < TAGE_HISTORIES_CONFIG::NUM_HISTORIES; ++j) {
+         folded_histories_for_indices_[j].update(history_register_);
+         folded_histories_for_tags_0_[j].update(history_register_);
+         folded_histories_for_tags_1_[j].update(history_register_);
+       }
+     }
+
+     path_history_ = path_history_ &
+                     ((1 << TAGE_HISTORIES_CONFIG::PATH_HISTORY_WIDTH) - 1);
+  }
+
+  void intialize_folded_history(void);
+
+  // Hash function for the path history used in creating table indices.
+  int64_t compute_path_hash(int64_t path_history, int max_width, int bank,
+                            int index_size) const;
+
+  // Derived constants
+  static constexpr int twice_num_histories_ =
+    2 * TAGE_HISTORIES_CONFIG::NUM_HISTORIES;
+  static constexpr Tage_History_Sizes<TAGE_HISTORIES_CONFIG> history_sizes_ =
+    {};
+  static constexpr Tage_Tag_Bits<TAGE_HISTORIES_CONFIG> tag_bits_ = {};
+
+  // Predictor State
+  Long_History_Register<TAGE_HISTORIES_CONFIG::MAX_HISTORY_SIZE> history_register_;
+  std::vector<Folded_History<TAGE_HISTORIES_CONFIG::MAX_HISTORY_SIZE>>
+    folded_histories_for_indices_;
+  std::vector<Folded_History<TAGE_HISTORIES_CONFIG::MAX_HISTORY_SIZE>>
+    folded_histories_for_tags_0_;
+  std::vector<Folded_History<TAGE_HISTORIES_CONFIG::MAX_HISTORY_SIZE>>
+    folded_histories_for_tags_1_;
+
+  int64_t path_history_;
+  int64_t head_old_;
+  int64_t path_history_old_;
+};
+
 template <class TAGE_CONFIG>
 class Tage {
  public:
   Tage(Random_Number_Generator& random_number_gen, int max_in_flight_branches) :
-      tagged_table_ptrs_(), history_register_(max_in_flight_branches),
+      tagged_table_ptrs_(), tage_histories(max_in_flight_branches),
       low_history_tagged_table_(), high_history_tagged_table_(),
       alt_selector_table_(), random_number_gen_(random_number_gen) {
     initialize_table_sizes();
-    intialize_folded_history();
     intialize_predictor_state();
   }
 
@@ -308,7 +382,7 @@ class Tage {
   void update_speculative_state(
     uint64_t br_pc, uint64_t br_target, Branch_Type br_type,
     bool final_prediction, Tage_Prediction_Info<TAGE_CONFIG>* prediction_info) {
-    push_into_history(br_pc, br_target, br_type, final_prediction,
+    tage_histories.push_into_history(br_pc, br_target, br_type, final_prediction,
                       prediction_info);
   }
 
@@ -319,7 +393,7 @@ class Tage {
     const int* tags    = prediction_info.tags;
 
     bool allocate_new_entry = (prediction_info.prediction != resolve_dir) &&
-                              (prediction_info.hit_bank < twice_num_histories_);
+                              (prediction_info.hit_bank < Tage_Histories<TAGE_CONFIG>::twice_num_histories_);
 
     if(prediction_info.hit_bank > 0) {
       // Manage the selection between longest matching and alternate
@@ -377,7 +451,7 @@ class Tage {
                                0xffe)) ^
                              (random_number_gen_() & 1));
 
-      for(; allocation_bank < twice_num_histories_; allocation_bank += 2) {
+      for(; allocation_bank < Tage_Histories<TAGE_CONFIG>::twice_num_histories_; allocation_bank += 2) {
         int  i    = allocation_bank + 1;  // REVISIT: is i needed?
         bool done = false;
         if(tables_enabled_.arr[i]) {
@@ -501,24 +575,24 @@ class Tage {
 
   void commit_state_at_retire(
     const Tage_Prediction_Info<TAGE_CONFIG>& prediction_info) {
-    history_register_.retire(prediction_info.num_global_history_bits);
-    path_history_old_ = path_history_;
+    tage_histories.history_register_.retire(prediction_info.num_global_history_bits);
+    tage_histories.path_history_old_ = tage_histories.path_history_;
   }
 
   void global_recover_speculative_state(
     const Tage_Prediction_Info<TAGE_CONFIG>& prediction_info) {
     int64_t num_flushed_bits =
       (prediction_info.global_history_head_checkpoint_ -
-       history_register_.head_idx());
+       tage_histories.history_register_.head_idx());
     for(int i = 0; i < num_flushed_bits; ++i) {
       for(int j = 0; j < TAGE_CONFIG::NUM_HISTORIES; ++j) {
-        folded_histories_for_indices_[j].update_reverse(history_register_);
-        folded_histories_for_tags_0_[j].update_reverse(history_register_);
-        folded_histories_for_tags_1_[j].update_reverse(history_register_);
+        tage_histories.folded_histories_for_indices_[j].update_reverse(tage_histories.history_register_);
+        tage_histories.folded_histories_for_tags_0_[j].update_reverse(tage_histories.history_register_);
+        tage_histories.folded_histories_for_tags_1_[j].update_reverse(tage_histories.history_register_);
       }
-      history_register_.rewind(1);
+      tage_histories.history_register_.rewind(1);
     }
-    path_history_ = prediction_info.path_history_checkpoint;
+    tage_histories.path_history_ = prediction_info.path_history_checkpoint;
   }
 
   void local_recover_speculative_state(
@@ -545,12 +619,7 @@ class Tage {
 
   void initialize_tag_bits(void);
   void initialize_table_sizes(void);
-  void intialize_folded_history(void);
   void intialize_predictor_state(void);
-
-  // Hash function for the path history used in creating table indices.
-  int64_t compute_path_hash(int64_t path_history, int max_width, int bank,
-                            int index_size) const;
 
   // Produce indices and tags for all Tagged table look-ups.
   void fill_table_indices_tags(
@@ -568,64 +637,14 @@ class Tage {
 
   void shift_tage_useful_bits(Tagged_Entry* table, int size);
 
-  void push_into_history(uint64_t br_pc, uint64_t br_target,
-                         Branch_Type br_type, bool branch_dir,
-                         Tage_Prediction_Info<TAGE_CONFIG>* prediction_info) {
-    head_old_           = history_register_.head_idx();
-    int num_bit_inserts = 2;
-    if(br_type.is_indirect && !br_type.is_conditional) {
-      num_bit_inserts = 3;
-    }
-
-    int pc_dir_hash = ((br_pc ^ (br_pc >> 2))) ^ branch_dir;
-    int path_hash   = br_pc ^ (br_pc >> 2) ^ (br_pc >> 4);
-    if((br_type.is_indirect && br_type.is_conditional) & branch_dir) {
-      pc_dir_hash = (pc_dir_hash ^ (br_target >> 2));
-      path_hash   = path_hash ^ (br_target >> 2) ^ (br_target >> 4);
-    }
-
-    prediction_info->num_global_history_bits = num_bit_inserts;
-    prediction_info->path_history_checkpoint = path_history_;
-    prediction_info->global_history_head_checkpoint_ =
-      history_register_.head_idx();
-
-    for(int i = 0; i < num_bit_inserts; ++i) {
-      history_register_.push_bit(pc_dir_hash & 1);
-      pc_dir_hash >>= 1;
-
-      path_history_ = (path_history_ << 1) ^ (path_hash & 127);
-      path_hash >>= 1;
-
-      for(int j = 0; j < TAGE_CONFIG::NUM_HISTORIES; ++j) {
-        folded_histories_for_indices_[j].update(history_register_);
-        folded_histories_for_tags_0_[j].update(history_register_);
-        folded_histories_for_tags_1_[j].update(history_register_);
-      }
-    }
-
-    path_history_ = path_history_ &
-                    ((1 << TAGE_CONFIG::PATH_HISTORY_WIDTH) - 1);
-  }
 
   // Derived constants
-  static constexpr int twice_num_histories_ = 2 * TAGE_CONFIG::NUM_HISTORIES;
-  static constexpr Tage_History_Sizes<TAGE_CONFIG>  history_sizes_  = {};
   static constexpr Tage_Tables_Enabled<TAGE_CONFIG> tables_enabled_ = {};
-  static constexpr Tage_Tag_Bits<TAGE_CONFIG>       tag_bits_       = {};
 
-  Tagged_Entry* tagged_table_ptrs_[twice_num_histories_ + 1];
+  Tagged_Entry* tagged_table_ptrs_[Tage_Histories<TAGE_CONFIG>::twice_num_histories_ + 1];
 
   // Predictor State
-  Long_History_Register<TAGE_CONFIG::MAX_HISTORY_SIZE> history_register_;
-  std::vector<Folded_History<TAGE_CONFIG::MAX_HISTORY_SIZE>>
-    folded_histories_for_indices_;
-  std::vector<Folded_History<TAGE_CONFIG::MAX_HISTORY_SIZE>>
-    folded_histories_for_tags_0_;
-  std::vector<Folded_History<TAGE_CONFIG::MAX_HISTORY_SIZE>>
-    folded_histories_for_tags_1_;
-
-  int64_t path_history_;
-
+  Tage_Histories<TAGE_CONFIG> tage_histories;
   Bimodal_Entry bimodal_table_[1 << TAGE_CONFIG::BIMODAL_LOG_TABLES_SIZE];
   Tagged_Entry
     low_history_tagged_table_[TAGE_CONFIG::SHORT_HISTORY_NUM_BANKS *
@@ -639,39 +658,37 @@ class Tage {
   int tick_;  // for resetting the useful bits
 
   Random_Number_Generator& random_number_gen_;
-  int64_t                  path_history_old_;
-  int64_t                  head_old_;
 };
 
-template <class TAGE_CONFIG>
-constexpr Tage_History_Sizes<TAGE_CONFIG> Tage<TAGE_CONFIG>::history_sizes_;
+template <class TAGE_HISTORIES_CONFIG>
+constexpr Tage_History_Sizes<TAGE_HISTORIES_CONFIG> Tage_Histories<TAGE_HISTORIES_CONFIG>::history_sizes_;
 
 template <class TAGE_CONFIG>
 constexpr Tage_Tables_Enabled<TAGE_CONFIG> Tage<TAGE_CONFIG>::tables_enabled_;
 
-template <class TAGE_CONFIG>
-constexpr Tage_Tag_Bits<TAGE_CONFIG> Tage<TAGE_CONFIG>::tag_bits_;
+template <class TAGE_HISTORIES_CONFIG>
+constexpr Tage_Tag_Bits<TAGE_HISTORIES_CONFIG> Tage_Histories<TAGE_HISTORIES_CONFIG>::tag_bits_;
 
 template <class TAGE_CONFIG>
 void Tage<TAGE_CONFIG>::initialize_table_sizes(void) {
   for(int i = 1; i < TAGE_CONFIG::FIRST_LONG_HISTORY_TABLE; ++i) {
     tagged_table_ptrs_[i] = low_history_tagged_table_;
   }
-  for(int i = TAGE_CONFIG::FIRST_LONG_HISTORY_TABLE; i <= twice_num_histories_;
+  for(int i = TAGE_CONFIG::FIRST_LONG_HISTORY_TABLE; i <= Tage_Histories<TAGE_CONFIG>::twice_num_histories_;
       ++i) {
     tagged_table_ptrs_[i] = high_history_tagged_table_;
   }
 }
 
-template <class TAGE_CONFIG>
-void Tage<TAGE_CONFIG>::intialize_folded_history(void) {
+template <class TAGE_HISTORIES_CONFIG>
+void Tage_Histories<TAGE_HISTORIES_CONFIG>::intialize_folded_history(void) {
   // insert dummy entries for the zeroth entry of the vector
-  for(int i = 0; i < TAGE_CONFIG::NUM_HISTORIES; i++) {
+  for(int i = 0; i < TAGE_HISTORIES_CONFIG::NUM_HISTORIES; i++) {
     // For some reason I cannot pass LOG_ENTRIES_PER_BANK to emplace_bank()
     // directly (gcc complains that variable is undefined), do not know why.
     // REVISIT: since I got rid of LOG_ENTRIES_PER_BANK as a constant, this
     // should be fine now.
-    const int LOG_ENTRIES_PER_BANK2 = TAGE_CONFIG::LOG_ENTRIES_PER_BANK;
+    const int LOG_ENTRIES_PER_BANK2 = TAGE_HISTORIES_CONFIG::LOG_ENTRIES_PER_BANK;
     folded_histories_for_indices_.emplace_back(history_sizes_.arr[i],
                                                LOG_ENTRIES_PER_BANK2);
     folded_histories_for_tags_0_.emplace_back(history_sizes_.arr[i],
@@ -684,13 +701,12 @@ void Tage<TAGE_CONFIG>::intialize_folded_history(void) {
 template <class TAGE_CONFIG>
 void Tage<TAGE_CONFIG>::intialize_predictor_state(void) {
   tick_                           = 0;
-  path_history_                   = 0;
-  random_number_gen_.phist_ptr_   = &path_history_old_;
-  random_number_gen_.ptghist_ptr_ = &head_old_;
+  random_number_gen_.phist_ptr_   = &tage_histories.path_history_old_;
+  random_number_gen_.ptghist_ptr_ = &tage_histories.head_old_;
 }
 
-template <class TAGE_CONFIG>
-int64_t Tage<TAGE_CONFIG>::compute_path_hash(int64_t path_history,
+template <class TAGE_HISTORIES_CONFIG>
+int64_t Tage_Histories<TAGE_HISTORIES_CONFIG>::compute_path_hash(int64_t path_history,
                                              int max_width, int bank,
                                              int index_size) const {
   int64_t temp1, temp2;
@@ -722,25 +738,25 @@ template <class TAGE_CONFIG>
 void Tage<TAGE_CONFIG>::fill_table_indices_tags(
   uint64_t br_pc, Tage_Prediction_Info<TAGE_CONFIG>* output) const {
   // Generate tags and indices, ignore bank bits for now.
-  for(int i = 1; i <= twice_num_histories_; i += 2) {
+  for(int i = 1; i <= Tage_Histories<TAGE_CONFIG>::twice_num_histories_; i += 2) {
     if(tables_enabled_.arr[i] || tables_enabled_.arr[i + 1]) {
-      int max_path_width = (history_sizes_.arr[(i - 1) / 2] >
+      int max_path_width = (tage_histories.history_sizes_.arr[(i - 1) / 2] >
                             TAGE_CONFIG::PATH_HISTORY_WIDTH) ?
                              TAGE_CONFIG::PATH_HISTORY_WIDTH :
-                             history_sizes_.arr[(i - 1) / 2];
-      int64_t path_hash = compute_path_hash(path_history_, max_path_width, i,
+                             tage_histories.history_sizes_.arr[(i - 1) / 2];
+      int64_t path_hash = tage_histories.compute_path_hash(tage_histories.path_history_, max_path_width, i,
                                             TAGE_CONFIG::LOG_ENTRIES_PER_BANK);
       int64_t index     = br_pc;
       index ^= br_pc >> (std::abs(TAGE_CONFIG::LOG_ENTRIES_PER_BANK - i) + 1);
-      index ^= folded_histories_for_indices_[(i - 1) / 2].get_value();
+      index ^= tage_histories.folded_histories_for_indices_[(i - 1) / 2].get_value();
       index ^= path_hash;
       output->indices[i] = index &
                            ((1 << TAGE_CONFIG::LOG_ENTRIES_PER_BANK) - 1);
 
       int64_t tag = br_pc;
-      tag ^= folded_histories_for_tags_0_[(i - 1) / 2].get_value();
-      tag ^= folded_histories_for_tags_1_[(i - 1) / 2].get_value() << 1;
-      output->tags[i] = tag & ((1 << tag_bits_.arr[(i - 1) / 2]) - 1);
+      tag ^= tage_histories.folded_histories_for_tags_0_[(i - 1) / 2].get_value();
+      tag ^= tage_histories.folded_histories_for_tags_1_[(i - 1) / 2].get_value() << 1;
+      output->tags[i] = tag & ((1 << tage_histories.tag_bits_.arr[(i - 1) / 2]) - 1);
 
       output->tags[i + 1]    = output->tags[i];
       output->indices[i + 1] = output->indices[i] ^
@@ -751,13 +767,13 @@ void Tage<TAGE_CONFIG>::fill_table_indices_tags(
 
   // Now add bank bits to the indices of high history tables.
   int temp = (br_pc ^
-              (path_history_ &
+              (tage_histories.path_history_ &
                ((int64_t(1)
-                 << history_sizes_
+                 << tage_histories.history_sizes_
                       .arr[(TAGE_CONFIG::FIRST_LONG_HISTORY_TABLE - 1) / 2]) -
                 1))) %
              TAGE_CONFIG::LONG_HISTORY_NUM_BANKS;
-  for(int i = TAGE_CONFIG::FIRST_LONG_HISTORY_TABLE; i <= twice_num_histories_;
+  for(int i = TAGE_CONFIG::FIRST_LONG_HISTORY_TABLE; i <= Tage_Histories<TAGE_CONFIG>::twice_num_histories_;
       ++i) {
     if(tables_enabled_.arr[i]) {
       output->indices[i] += (temp << TAGE_CONFIG::LOG_ENTRIES_PER_BANK);
@@ -767,7 +783,7 @@ void Tage<TAGE_CONFIG>::fill_table_indices_tags(
   }
 
   // Now add bank bits to the indices of low history tables.
-  temp = (br_pc ^ (path_history_ & ((1 << history_sizes_.arr[0]) - 1))) %
+  temp = (br_pc ^ (tage_histories.path_history_ & ((1 << tage_histories.history_sizes_.arr[0]) - 1))) %
          TAGE_CONFIG::SHORT_HISTORY_NUM_BANKS;
   for(int i = 1; i <= TAGE_CONFIG::FIRST_LONG_HISTORY_TABLE - 1; ++i) {
     if(tables_enabled_.arr[i]) {


### PR DESCRIPTION
Adding a tage_histories object to track all the various components that make up tage history
(multiple sized histories, path histories)