### PR TITLE
Refactor pin_lib to use Intel XED for static decoding.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/deps/mbuild"]
 	path = src/deps/mbuild
-	url = git@github.com:intelxed/mbuild.git
+	url = https://github.com/intelxed/mbuild.git
 [submodule "src/deps/xed"]
 	path = src/deps/xed
-	url = git@github.com:intelxed/xed.git
+	url = https://github.com/intelxed/xed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "src/deps/mbuild"]
+	path = src/deps/mbuild
+	url = git@github.com:intelxed/mbuild.git
+[submodule "src/deps/xed"]
+	path = src/deps/xed
+	url = git@github.com:intelxed/xed.git

--- a/docs/system_requirements.md
+++ b/docs/system_requirements.md
@@ -7,7 +7,8 @@ Other versions of the same software may work, but have not been tested.
 Scarab relies on the following software packages:
 
 ## Required Packages
-* Intel [PIN 3.5](https://software.intel.com/en-us/articles/program-recordreplay-toolkit).
+* [Intel PIN 3.5](https://software.intel.com/en-us/articles/program-recordreplay-toolkit)
+* [Intel XED 12.01](https://github.com/intelxed/xed/releases)
 * g++ 7.3.1
 * gcc 7.3.1
 * Clang 5.0.1

--- a/docs/system_requirements.md
+++ b/docs/system_requirements.md
@@ -8,11 +8,11 @@ Scarab relies on the following software packages:
 
 ## Required Packages
 * [Intel PIN 3.5](https://software.intel.com/en-us/articles/program-recordreplay-toolkit)
-* [Intel XED 12.01](https://github.com/intelxed/xed/releases)
 * g++ 7.3.1
 * gcc 7.3.1
 * Clang 5.0.1
 * Python 3.6.3
+* [Intel XED 12.01](https://github.com/intelxed/xed/releases) (included as a git submodule)
 
 ## Required Python Packages
 See `$SCARAB_ROOT/bin/requirements.txt`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ add_compile_options(
         "$<$<COMPILE_LANGUAGE:CXX>:${warn_cxx_flags}>"
 )
 
+add_subdirectory(deps)
 add_subdirectory(ramulator)
 add_subdirectory(pin/pin_lib)
 add_subdirectory(pin/pin_exec/testing)
@@ -48,3 +49,4 @@ target_link_libraries(scarab
         ramulator
         pin_lib_for_scarab
 )
+

--- a/src/deps/CMakeLists.txt
+++ b/src/deps/CMakeLists.txt
@@ -1,0 +1,27 @@
+find_package(Git)
+if(GIT_FOUND)
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/..
+                    RESULT_VARIABLE GIT_SUBMOD_RESULT)
+    if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+        message(FATAL_ERROR "Updating git submodules failed: ${GIT_SUBMOD_RESULT}")
+    endif()
+else()
+  message(FATAL_ERROR "Could not find git binary in the system")
+endif()
+
+find_package(Python3)
+if(Python3_FOUND)
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/xed/mfile.py
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/xed"
+        COMMAND_ECHO STDOUT
+    )
+else()
+  message(FATAL_ERROR "Could not find python3 in the system")
+endif()
+
+set($ENV{TARGET} ia32)
+add_library(xed INTERFACE)
+target_include_directories(xed INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/xed/include/public/xed/)
+target_include_directories(xed INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/xed/obj/)

--- a/src/pin/pin_exec/makefile.rules
+++ b/src/pin/pin_exec/makefile.rules
@@ -60,7 +60,8 @@ SOURCE_FILES := analysis_functions.cc globals.cc main_loop.cc exception_handling
 SOURCE_OBJFILES := $(patsubst %.cc,$(OBJDIR)%.o,$(SOURCE_FILES))
 
 SCARAB_DIR ?= ../../
-TOOL_CXXFLAGS += -std=c++14 -g3 -static -I$(SCARAB_DIR)
+#allow deprecated-declarations to enable compiling with newer PIN version e.g. 3.15 that define new APIs
+TOOL_CXXFLAGS += -std=c++14 -g3 -static -I$(SCARAB_DIR) -Wno-error=deprecated-declarations
 TOOL_LDFLAGS += -std=c++14
 
 ##############################################################

--- a/src/pin/pin_exec/pin_exec.cpp
+++ b/src/pin/pin_exec/pin_exec.cpp
@@ -225,7 +225,8 @@ void instrumentation_func_per_instruction(INS ins, void* v) {
       // Inserting functions to create a compressed op
       pin_decoder_insert_analysis_functions(ins);
 
-      if(INS_IsSyscall(ins) || is_ifetch_barrier(ins)) {
+      xed_decoded_inst_t* xed_ins = INS_XedDec(ins);
+      if(INS_IsSyscall(ins) || is_ifetch_barrier(xed_ins)) {
         insert_processing_for_syscalls(ins);
       } else {
         insert_checks_for_control_flow(ins);

--- a/src/pin/pin_exec/read_mem_map.h
+++ b/src/pin/pin_exec/read_mem_map.h
@@ -30,6 +30,8 @@
 #include <stdio.h>
 #include <vector>
 
+using namespace std;
+
 struct pageTableEntryStruct {
   uint64_t addr_begin;
   uint64_t addr_end;

--- a/src/pin/pin_lib/CMakeLists.txt
+++ b/src/pin/pin_lib/CMakeLists.txt
@@ -6,5 +6,16 @@ add_library(pin_lib_for_scarab
         pin_scarab_common_lib.h
         uop_generator.c
         uop_generator.h
+        x86_decoder.cc
+        x86_decoder.h
+        x87_stack_delta.h
+        x87_stack_delta.cc
+        gather_scatter_addresses.h
+        gather_scatter_addresses.cc
 )
+
+set($ENV{TARGET} ia32)
 target_include_directories(pin_lib_for_scarab PRIVATE ../..)
+target_include_directories(pin_lib_for_scarab PRIVATE $ENV{XED_ROOT}/include/public/xed/)
+target_include_directories(pin_lib_for_scarab PRIVATE $ENV{XED_ROOT}/obj/)
+

--- a/src/pin/pin_lib/CMakeLists.txt
+++ b/src/pin/pin_lib/CMakeLists.txt
@@ -13,9 +13,7 @@ add_library(pin_lib_for_scarab
         gather_scatter_addresses.h
         gather_scatter_addresses.cc
 )
-
-set($ENV{TARGET} ia32)
 target_include_directories(pin_lib_for_scarab PRIVATE ../..)
-target_include_directories(pin_lib_for_scarab PRIVATE $ENV{XED_ROOT}/include/public/xed/)
-target_include_directories(pin_lib_for_scarab PRIVATE $ENV{XED_ROOT}/obj/)
+target_link_libraries(pin_lib_for_scarab PUBLIC xed)
+
 

--- a/src/pin/pin_lib/decoder.cc
+++ b/src/pin/pin_lib/decoder.cc
@@ -26,8 +26,12 @@
 
 #include "decoder.h"
 #include "x87_stack_delta.h"
+#include "gather_scatter_addresses.h"
 
 #include "pin_scarab_common_lib.h"
+
+
+using namespace std;
 
 KNOB<BOOL> Knob_debug(KNOB_MODE_WRITEONCE, "pintool", "debug", "0",
                       "always add instructions to print map");
@@ -35,86 +39,26 @@ KNOB<BOOL> Knob_translate_x87_regs(
   KNOB_MODE_WRITEONCE, "pintool", "translate_x87_regs", "1",
   "translate Pin's relative x87 regs to Scarab's absolute regs");
 
+// the most recently filled instruction
+static ctype_pin_inst* filled_inst_info;
+static ctype_pin_inst  tmp_inst_info;
+
+
 /************************** Data Type Definitions *****************************/
-#define REG(x) SCARAB_REG_##x,
-typedef enum Reg_Id_struct {
-#include "../../isa/x86_regs.def"
-  SCARAB_NUM_REGS
-} Reg_Id;
-#undef REG
-
-struct iclass_to_scarab {
-  int     opcode;
-  int     lane_width_bytes;
-  int     num_simd_lanes;
-  MemHint mem_hint;
-};
-
-enum Reg_Array_Id {
-  SRC_REGS,
-  DST_REGS,
-  LD1_ADDR_REGS,
-  LD2_ADDR_REGS,
-  ST_ADDR_REGS,
-  NUM_REG_ARRAYS
-};
-
-struct Reg_Array_Info {
-  size_t  array_offset;
-  uint8_t ctype_pin_inst::*num;
-  uint8_t                  max_num;
-};
-
-/**************************** Global Variables ********************************/
-// Global static instructions map
-typedef unordered_map<ADDRINT, ctype_pin_inst*> inst_info_map;
-typedef inst_info_map::iterator                 inst_info_map_p;
-inst_info_map                                   inst_info_storage;
-
-// helper array used by add_reg()
-static Reg_Array_Info reg_array_infos[NUM_REG_ARRAYS] = {
-  {offsetof(ctype_pin_inst, src_regs), &ctype_pin_inst::num_src_regs,
-   MAX_SRC_REGS_NUM},
-  {offsetof(ctype_pin_inst, dst_regs), &ctype_pin_inst::num_dst_regs,
-   MAX_DST_REGS_NUM},
-  {offsetof(ctype_pin_inst, ld1_addr_regs), &ctype_pin_inst::num_ld1_addr_regs,
-   MAX_MEM_ADDR_REGS_NUM},
-  {offsetof(ctype_pin_inst, ld2_addr_regs), &ctype_pin_inst::num_ld2_addr_regs,
-   MAX_MEM_ADDR_REGS_NUM},
-  {offsetof(ctype_pin_inst, st_addr_regs), &ctype_pin_inst::num_st_addr_regs,
-   MAX_MEM_ADDR_REGS_NUM},
-};
-
-// maps for translation from pin to scarab
-uint8_t reg_compress_map[(int)REG_LAST + 1] = {0};  // Assuming REG_INV is 0
-// Assuming OP_INV is 0
-iclass_to_scarab iclass_to_scarab_map[XED_ICLASS_LAST] = {{0}};
 
 // Globals used for communication between analysis functions
 uint32_t       glb_opcode, glb_actually_taken;
 deque<ADDRINT> glb_ld_vaddrs, glb_st_vaddrs;
 
-// the most recently filled instruction
-static ctype_pin_inst* filled_inst_info;
-static ctype_pin_inst  tmp_inst_info;
-
 std::ostream*         glb_err_ostream;
 bool                  glb_translate_x87_regs;
 std::set<std::string> unknown_opcodes;
+inst_info_map                                   inst_info_storage;
+static std::map<xed_reg_enum_t, LEVEL_BASE::REG> reg_xed_to_pin_map;
+extern scatter_info_map                                    scatter_info_storage;
 
 /********************* Private Functions Prototypes ***************************/
-static void     init_reg_compress_map();
-static void     init_pin_opcode_convert();
-static void     add_reg(ctype_pin_inst* info, Reg_Array_Id id, uint8_t reg);
-static uint8_t  reg_compress(REG pin_reg, ADDRINT ip);
 ctype_pin_inst* get_inst_info_obj(const INS& ins);
-
-void     fill_in_basic_info(ctype_pin_inst* info, const INS& ins);
-uint32_t add_dependency_info(ctype_pin_inst* info, const INS& ins);
-void     fill_in_simd_info(ctype_pin_inst* info, const INS& ins,
-                           uint32_t max_op_width);
-void     apply_x87_bug_workaround(ctype_pin_inst* info, const INS& ins);
-void     fill_in_cf_info(ctype_pin_inst* info, const INS& ins);
 void     insert_analysis_functions(ctype_pin_inst* info, const INS& ins);
 void     print_err_if_invalid(ctype_pin_inst* info, const INS& ins);
 
@@ -127,10 +71,29 @@ void get_st_ea(ADDRINT addr);
 void get_branch_dir(bool taken);
 void create_compressed_op(ADDRINT iaddr);
 
+void update_gather_scatter_num_ld_or_st(const ADDRINT                   iaddr,
+                                        const gather_scatter_info::type type,
+                                        const uint      num_maskon_memops,
+                                        ctype_pin_inst* info);
+static void verify_mem_access_infos(
+  const vector<PIN_MEM_ACCESS_INFO> computed_infos,
+  const PIN_MULTI_MEM_ACCESS_INFO* infos_from_pin, bool base_reg_is_gr32);
+std::vector<PIN_MEM_ACCESS_INFO> compute_mem_access_infos(
+                              const CONTEXT* ctxt, gather_scatter_info *info);
+ADDRDELTA compute_base_reg_addr_contribution(const CONTEXT* ctxt,
+                                             gather_scatter_info* info);
+ADDRDELTA compute_base_index_addr_contribution(
+                const PIN_REGISTER& vector_index_reg_val, const UINT32 lane_id,
+                                               gather_scatter_info* info);
+PIN_MEMOP_ENUM type_to_PIN_MEMOP_ENUM(gather_scatter_info* info);
+bool           extract_mask_on(const PIN_REGISTER& mask_reg_val_buf,
+                               const UINT32        lane_id,
+                               gather_scatter_info* info);
+
 /**************************** Public Functions ********************************/
 void pin_decoder_init(bool translate_x87_regs, std::ostream* err_ostream) {
-  init_reg_compress_map();
-  init_pin_opcode_convert();
+  init_x86_decoder(err_ostream);
+  init_reg_xed_to_pin_map();
   init_x87_stack_delta();
   glb_translate_x87_regs = translate_x87_regs;
   if(err_ostream) {
@@ -142,20 +105,31 @@ void pin_decoder_init(bool translate_x87_regs, std::ostream* err_ostream) {
 
 void pin_decoder_insert_analysis_functions(const INS& ins) {
   ctype_pin_inst* info = get_inst_info_obj(ins);
-  fill_in_basic_info(info, ins);
-  if(INS_IsVgather(ins) || INS_IsVscatter(ins)) {
-    add_to_gather_scatter_info_storage(INS_Address(ins), INS_IsVgather(ins),
-                                       INS_IsVscatter(ins), INS_Category(ins));
+  xed_decoded_inst_t* xed_ins = INS_XedDec(ins);
+  fill_in_basic_info(info, xed_ins);
+
+  info->instruction_addr = INS_Address(ins);
+  // Note: should be overwritten for a taken control flow instruction
+  info->instruction_next_addr = INS_NextAddress(ins);
+  if(INS_IsDirectBranchOrCall(ins)) {
+    info->branch_target = INS_DirectBranchOrCallTargetAddress(ins);
   }
-  uint32_t max_op_width = add_dependency_info(info, ins);
-  fill_in_simd_info(info, ins, max_op_width);
+
+  if(INS_IsVgather(ins) || INS_IsVscatter(ins)) {
+    xed_category_enum_t category = XED_INS_Category(xed_ins);
+    scatter_info_storage[INS_Address(ins)] = add_to_gather_scatter_info_storage(
+                                           INS_Address(ins), INS_IsVgather(ins),
+                                           INS_IsVscatter(ins), category);
+  }
+  uint32_t max_op_width = add_dependency_info(info, xed_ins);
+  fill_in_simd_info(info, xed_ins, max_op_width);
   if(INS_IsVgather(ins) || INS_IsVscatter(ins)) {
     finalize_scatter_info(INS_Address(ins), info);
   }
-  apply_x87_bug_workaround(info, ins);
-  fill_in_cf_info(info, ins);
+  apply_x87_bug_workaround(info, xed_ins);
+  fill_in_cf_info(info, xed_ins);
   insert_analysis_functions(info, ins);
-  print_err_if_invalid(info, ins);
+  print_err_if_invalid(info, xed_ins);
 }
 
 ctype_pin_inst* pin_decoder_get_latest_inst() {
@@ -220,207 +194,6 @@ ctype_pin_inst* get_inst_info_obj(const INS& ins) {
   return info;
 }
 
-void fill_in_basic_info(ctype_pin_inst* info, const INS& ins) {
-  int category           = INS_Category(ins);
-  info->size             = INS_Size(ins);
-  info->instruction_addr = INS_Address(ins);
-
-  // Note: should be overwritten for a taken control flow instruction
-  info->instruction_next_addr = INS_NextAddress(ins);
-
-  info->true_op_type = INS_Opcode(ins);
-  info->op_type      = iclass_to_scarab_map[INS_Opcode(ins)].opcode;
-  assert(INS_Mnemonic(ins).size() < sizeof(info->pin_iclass));
-  strcpy(info->pin_iclass, INS_Mnemonic(ins).c_str());
-
-  if((category == XED_CATEGORY_SSE) || (category == XED_CATEGORY_FCMOV) ||
-     (category == XED_CATEGORY_X87_ALU)) {
-    info->is_fp = 1;
-  }
-  info->is_string         = (category == XED_CATEGORY_STRINGOP);
-  info->is_call           = (category == XED_CATEGORY_CALL);
-  info->is_move           = (category == XED_CATEGORY_DATAXFER ||
-                   info->op_type == OP_MOV);
-  info->is_prefetch       = (category == XED_CATEGORY_PREFETCH);
-  info->has_push          = (category == XED_CATEGORY_PUSH ||
-                    category == XED_CATEGORY_CALL);
-  info->has_pop           = (category == XED_CATEGORY_POP ||
-                   category == XED_CATEGORY_RET);
-  info->is_lock           = INS_LockPrefix(ins);
-  info->is_repeat         = INS_HasRealRep(ins);
-  info->is_gather_scatter = INS_IsVgather(ins) || INS_IsVscatter(ins);
-}
-
-uint32_t add_dependency_info(ctype_pin_inst* info, const INS& ins) {
-  uint32_t      max_op_width = 0;
-  const ADDRINT iaddr        = INS_Address(ins);
-  bool is_gather_or_scatter  = INS_IsVgather(ins) || INS_IsVscatter(ins);
-  if(info->op_type != OP_NOP) {
-    for(UINT32 ii = 0; ii < INS_OperandCount(ins); ii++) {
-      if(INS_OperandIsReg(ins, ii)) {
-        REG     pin_reg        = INS_OperandReg(ins, ii);
-        uint8_t scarab_reg     = (uint8_t)reg_compress(pin_reg, iaddr);
-        bool    operandRead    = INS_OperandRead(ins, ii);
-        bool    operandWritten = INS_OperandWritten(ins, ii);
-        if(operandRead) {
-          add_reg(info, SRC_REGS, scarab_reg);
-        }
-        if(operandWritten) {
-          add_reg(info, DST_REGS, scarab_reg);
-        }
-        if(scarab_reg >= SCARAB_REG_FP0 && scarab_reg <= SCARAB_REG_FP7)
-          info->is_fp = TRUE;
-        if(scarab_reg != SCARAB_REG_ZPS) {
-          max_op_width = std::max(max_op_width, INS_OperandWidth(ins, ii));
-        }
-        if(is_gather_or_scatter) {
-          set_gather_scatter_reg_operand_info(iaddr, pin_reg, operandRead,
-                                              operandWritten);
-        }
-      } else if(INS_OperandIsAddressGenerator(ins, ii)) {  // LEA
-        ASSERTX(!is_gather_or_scatter);
-        uint8_t scarab_base_reg = (uint8_t)reg_compress(
-          INS_OperandMemoryBaseReg(ins, ii), iaddr);
-        uint8_t scarab_index_reg = (uint8_t)reg_compress(
-          INS_OperandMemoryIndexReg(ins, ii), iaddr);
-        add_reg(info, SRC_REGS, scarab_base_reg);
-        add_reg(info, SRC_REGS, scarab_index_reg);
-      } else if(INS_OperandIsMemory(ins, ii)) {
-        REG     pin_base_reg     = INS_OperandMemoryBaseReg(ins, ii);
-        uint8_t scarab_base_reg  = (uint8_t)reg_compress(pin_base_reg, iaddr);
-        REG     pin_index_reg    = INS_OperandMemoryIndexReg(ins, ii);
-        uint8_t scarab_index_reg = (uint8_t)reg_compress(pin_index_reg, iaddr);
-        if(is_gather_or_scatter) {
-          set_gather_scatter_memory_operand_info(
-            iaddr, pin_base_reg, pin_index_reg,
-            INS_OperandMemoryDisplacement(ins, ii),
-            INS_OperandMemoryScale(ins, ii), INS_OperandReadOnly(ins, ii),
-            INS_OperandWrittenOnly(ins, ii));
-        }
-        if(INS_OperandRead(ins, ii)) {
-          ASSERTX(info->num_ld < MAX_LD_NUM);
-          add_reg(info, (Reg_Array_Id)(LD1_ADDR_REGS + info->num_ld),
-                  scarab_base_reg);
-          add_reg(info, (Reg_Array_Id)(LD1_ADDR_REGS + info->num_ld),
-                  scarab_index_reg);
-          info->num_ld++;
-          info->ld_size = INS_MemoryReadSize(ins);
-        }
-        if(INS_OperandWritten(ins, ii)) {
-          ASSERTX(info->num_st < MAX_ST_NUM);
-          add_reg(info, (Reg_Array_Id)(ST_ADDR_REGS + info->num_st),
-                  scarab_base_reg);
-          add_reg(info, (Reg_Array_Id)(ST_ADDR_REGS + info->num_st),
-                  scarab_index_reg);
-          info->num_st++;
-          info->st_size = INS_MemoryWriteSize(ins);
-        }
-      }
-      info->has_immediate |= INS_OperandIsImmediate(ins, ii);
-      if(is_gather_or_scatter) {
-        ASSERTX(!(info->has_immediate));
-      }
-    }
-  }
-  return max_op_width;
-}
-
-void fill_in_simd_info(ctype_pin_inst* info, const INS& ins,
-                       uint32_t max_op_width) {
-  iclass_to_scarab iclass_info = iclass_to_scarab_map[INS_Opcode(ins)];
-  if(info->op_type != OP_INV) {
-    ASSERTX(max_op_width % 8 == 0);
-    int lane_width_bytes = iclass_info.lane_width_bytes;
-    int num_simd_lanes   = iclass_info.num_simd_lanes;
-    if(lane_width_bytes == -1) {
-      info->lane_width_bytes = max_op_width / 8;
-      info->num_simd_lanes   = 1;
-    } else if(num_simd_lanes == -1) {
-      info->lane_width_bytes = lane_width_bytes;
-      ASSERTX((max_op_width / 8) % lane_width_bytes == 0);
-      info->num_simd_lanes = max_op_width / 8 / lane_width_bytes;
-    } else {
-      info->lane_width_bytes = lane_width_bytes;
-      info->num_simd_lanes   = num_simd_lanes;
-    }
-  }
-
-  info->is_simd = 0;
-  for(int i = 0; i < info->num_src_regs; ++i) {
-    if(info->src_regs[i] >= SCARAB_REG_ZMM0 &&
-       info->src_regs[i] <= SCARAB_REG_ZMM31) {
-      info->is_simd = 1;
-      return;
-    }
-  }
-  for(int i = 0; i < info->num_dst_regs; ++i) {
-    if(info->dst_regs[i] >= SCARAB_REG_ZMM0 &&
-       info->dst_regs[i] <= SCARAB_REG_ZMM31) {
-      info->is_simd = 1;
-      return;
-    }
-  }
-}
-
-void apply_x87_bug_workaround(ctype_pin_inst* info, const INS& ins) {
-  // Workaround for a bug in Pin 2.8, see
-  // http://tech.groups.yahoo.com/group/pinheads/message/6082
-  if(pops_x87_stack(INS_Opcode(ins)) && info->num_dst_regs == 1 &&
-     info->dst_regs[0] == SCARAB_REG_FP0) {
-    int other_reg = SCARAB_REG_FP0;
-    for(int i = 0; i < info->num_src_regs; ++i) {
-      if(info->src_regs[i] != SCARAB_REG_FP0) {
-        ASSERTX(other_reg == SCARAB_REG_FP0);
-        other_reg = info->src_regs[i];
-      }
-    }
-    // not checking for other_reg != SCARAB_REG_FP0 because sometimes the
-    // compiler may use FSTP ST0 or smth to simply pop the x87 stack
-    info->dst_regs[0] = other_reg;
-  }
-}
-
-void fill_in_cf_info(ctype_pin_inst* info, const INS& ins) {
-  int category  = INS_Category(ins);
-  info->cf_type = NOT_CF;
-
-  if(INS_IsRet(ins)) {
-    info->cf_type = CF_RET;
-  } else if(INS_IsIndirectBranchOrCall(ins)) {
-    // indirect
-    if(category == XED_CATEGORY_UNCOND_BR)
-      info->cf_type = CF_IBR;
-    else if(category == XED_CATEGORY_COND_BR)
-      info->cf_type = CF_ICO;  // ICBR not supported by Scarab, so map it to ICO
-    else if(category == XED_CATEGORY_CALL)
-      info->cf_type = CF_ICALL;
-
-  } else if(INS_IsDirectBranchOrCall(ins)) {
-    // direct
-    if(category == XED_CATEGORY_UNCOND_BR)
-      info->cf_type = CF_BR;
-    else if(category == XED_CATEGORY_COND_BR)
-      info->cf_type = CF_CBR;
-    else if(category == XED_CATEGORY_CALL)
-      info->cf_type = CF_CALL;
-    info->branch_target = INS_DirectBranchOrCallTargetAddress(ins);
-  } else if(INS_IsSyscall(ins) || INS_IsSysret(ins) || INS_IsInterrupt(ins)) {
-    info->cf_type = CF_SYS;
-  }
-
-  info->is_ifetch_barrier = is_ifetch_barrier(ins);
-}
-
-uint8_t is_ifetch_barrier(const INS& ins) {
-  int category = INS_Category(ins);
-  int opcode   = INS_Opcode(ins);
-  return (category == XED_CATEGORY_IO) ||
-         (category == XED_CATEGORY_INTERRUPT) ||
-         (category == XED_CATEGORY_VTX) || (category == XED_CATEGORY_SYSTEM) ||
-         (category == XED_CATEGORY_SYSCALL) ||
-         (category == XED_CATEGORY_SYSRET) || (opcode == XED_ICLASS_PAUSE);
-}
-
 void insert_analysis_functions(ctype_pin_inst* info, const INS& ins) {
   if(Knob_translate_x87_regs.Value()) {
     INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)get_opcode, IARG_UINT32,
@@ -455,33 +228,6 @@ void insert_analysis_functions(ctype_pin_inst* info, const INS& ins) {
 
   INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)create_compressed_op,
                  IARG_INST_PTR, IARG_END);
-}
-
-void print_err_if_invalid(ctype_pin_inst* info, const INS& ins) {
-  if(info->op_type == OP_INV) {
-    (*glb_err_ostream)
-      << "Unmapped instruction at "
-      << "EIP: " << std::hex << (uint64_t)INS_Address(ins)
-      << ", opcode: " << INS_Mnemonic(ins)
-      << ", category: " << CATEGORY_StringShort(INS_Category(ins)) << std::dec
-      << ", opcode index: " << INS_Opcode(ins)
-      << ", hasrealrep: " << (int)info->is_repeat
-      << ", is_lock: " << (int)info->is_lock
-      << ", num_ld: " << (int)info->num_ld << ", num_st: " << (int)info->num_st
-      << ", num_src_regs: " << (int)info->num_src_regs
-      << ", num_dst_regs: " << (int)info->num_dst_regs
-      << ", num_ld1_addr_regs: " << (int)info->num_ld1_addr_regs
-      << ", num_ld2_addr_regs: " << (int)info->num_ld2_addr_regs
-      << ", num_st_addr_regs: " << (int)info->num_st_addr_regs
-      << ", num_simd_lanes: " << (int)info->num_simd_lanes
-      << ", lane_width_bytes: " << (int)info->lane_width_bytes
-      << ". Look at README in pin/pin_lib on how to map new instructions"
-      << std::endl;
-    glb_err_ostream->flush();
-    if(Knob_debug.Value()) {
-      unknown_opcodes.insert(INS_Mnemonic(ins));
-    }
-  }
 }
 
 // int64_t heartbeat = 0;
@@ -543,10 +289,6 @@ void create_compressed_op(ADDRINT iaddr) {
   // heartbeat += 1;
 }
 
-void get_opcode(UINT32 opcode) {
-  glb_opcode = opcode;
-}
-
 void get_gather_scatter_eas(bool is_gather, CONTEXT* ctxt,
                             PIN_MULTI_MEM_ACCESS_INFO* mem_access_info) {
   const vector<PIN_MEM_ACCESS_INFO> gather_scatter_mem_access_infos =
@@ -580,6 +322,10 @@ void get_gather_scatter_eas(bool is_gather, CONTEXT* ctxt,
   }
 }
 
+void get_opcode(UINT32 opcode) {
+  glb_opcode = opcode;
+}
+
 void get_ld_ea(ADDRINT addr) {
   glb_ld_vaddrs.push_back(addr);
 }
@@ -597,1501 +343,549 @@ void get_branch_dir(bool taken) {
   glb_actually_taken = taken;
 }
 
-static compressed_reg_t reg_compress(REG pin_reg, ADDRINT ip) {
-  compressed_reg_t result = reg_compress_map[pin_reg];
-  if(result == SCARAB_REG_INV && (int)pin_reg != 0) {
-    (*glb_err_ostream) << "Invalid register operand "
-                       << LEVEL_BASE::REG_StringShort(pin_reg)
-                       << " at: " << std::hex << ip << std::endl;
+void update_gather_scatter_num_ld_or_st(const ADDRINT                   iaddr,
+                                        const gather_scatter_info::type type,
+                                        const uint      num_maskon_memops,
+                                        ctype_pin_inst* info) {
+  ASSERTX(info->is_simd);
+  ASSERTX(info->is_gather_scatter);
+  ASSERTX(1 == scatter_info_storage.count(iaddr));
+  ASSERTX(type == scatter_info_storage[iaddr].get_type());
+  // number of actual mask on loads/stores should be less or equal to total of
+  // mem ops (both mask on and off) in the gather/scatter instruction
+  UINT32 total_mask_on_and_off_mem_ops =
+    scatter_info_storage[iaddr].get_num_mem_ops();
+  switch(type) {
+    case gather_scatter_info::GATHER:
+      assert(num_maskon_memops <= total_mask_on_and_off_mem_ops);
+      info->num_ld = num_maskon_memops;
+      break;
+    case gather_scatter_info::SCATTER:
+      assert(num_maskon_memops <= total_mask_on_and_off_mem_ops);
+      info->num_st = num_maskon_memops;
+      break;
+    default:
+      ASSERTX(false);
+      break;
   }
-  return result;
 }
 
-static void add_reg(ctype_pin_inst* info, Reg_Array_Id id, uint8_t reg) {
-  if(reg == SCARAB_REG_INV)
-    return;
-  if(reg >= SCARAB_REG_CS && reg <= SCARAB_REG_RIP)
-    return;  // ignoring EIP and segment regs
+vector<PIN_MEM_ACCESS_INFO>
+  get_gather_scatter_mem_access_infos_from_gather_scatter_info(
+    const CONTEXT* ctxt, const PIN_MULTI_MEM_ACCESS_INFO* infos_from_pin) {
+  ADDRINT iaddr;
+  PIN_GetContextRegval(ctxt, REG_INST_PTR, (UINT8*)&iaddr);
+  ASSERTX(1 == scatter_info_storage.count(iaddr));
+  vector<PIN_MEM_ACCESS_INFO> computed_infos =
+    compute_mem_access_infos(ctxt, &scatter_info_storage[iaddr]);
+  verify_mem_access_infos(computed_infos, infos_from_pin,
+                          scatter_info_storage[iaddr].base_reg_is_gr32());
 
-  uint8_t* array = ((uint8_t*)info) + reg_array_infos[id].array_offset;
-  uint8_t ctype_pin_inst::*num_ptr = reg_array_infos[id].num;
-  //  uint8_t * num   = &(info->*num_ptr);
-  uint8_t max_num = reg_array_infos[id].max_num;
-  ASSERTX(id < NUM_REG_ARRAYS);
-  ASSERTX(info->*num_ptr < max_num);
-  array[info->*num_ptr] = reg;
-  (info->*num_ptr)++;
+  return computed_infos;
 }
 
-static void init_reg_compress_map(void) {
-  ASSERTX(SCARAB_REG_INV == 0);
+static void verify_mem_access_infos(
+  const vector<PIN_MEM_ACCESS_INFO> computed_infos,
+  const PIN_MULTI_MEM_ACCESS_INFO* infos_from_pin, bool base_reg_is_gr32) {
+  for(UINT32 lane_id = 0; lane_id < infos_from_pin->numberOfMemops; lane_id++) {
+    ADDRINT        addr_from_pin = infos_from_pin->memop[lane_id].memoryAddress;
+    PIN_MEMOP_ENUM type_from_pin = infos_from_pin->memop[lane_id].memopType;
+    UINT32         size_from_pin = infos_from_pin->memop[lane_id].bytesAccessed;
+    bool           mask_on_from_pin = infos_from_pin->memop[lane_id].maskOn;
 
-  // Makes sure src_regs is wide enough for Scarab registers.
-  assert(SCARAB_NUM_REGS < (1 << (sizeof(compressed_reg_t) * 8)));
+    // as late as PIN 3.13, there is a bug where PIN will not correctly compute
+    // the full 64 addresses of gathers/scatters if the base register is a
+    // 32-bit register and holds a negative value. The low 32 bits, however,
+    // appear to be correct, so we check against that
+    ADDRINT addr_mask;
+    if(base_reg_is_gr32) {
+      addr_mask = 0xFFFFFFFF;
+    } else {
+      addr_mask = -1;
+    }
+    ASSERTX((computed_infos[lane_id].memoryAddress & addr_mask) ==
+            (addr_from_pin & addr_mask));
+    ASSERTX(computed_infos[lane_id].memopType == type_from_pin);
+    ASSERTX(computed_infos[lane_id].bytesAccessed == size_from_pin);
+    ASSERTX(computed_infos[lane_id].maskOn == mask_on_from_pin);
+  }
+}
 
-  reg_compress_map[0]                  = 0;
-  reg_compress_map[(int)REG_GR_BASE]   = SCARAB_REG_RDI;
-  reg_compress_map[(int)REG_EDI]       = SCARAB_REG_RDI;
-  reg_compress_map[(int)REG_GDI]       = SCARAB_REG_RDI;
-  reg_compress_map[(int)REG_ESI]       = SCARAB_REG_RSI;
-  reg_compress_map[(int)REG_GSI]       = SCARAB_REG_RSI;
-  reg_compress_map[(int)REG_EBP]       = SCARAB_REG_RBP;
-  reg_compress_map[(int)REG_GBP]       = SCARAB_REG_RBP;
-  reg_compress_map[(int)REG_ESP]       = SCARAB_REG_RSP;
-  reg_compress_map[(int)REG_STACK_PTR] = SCARAB_REG_RSP;
-  reg_compress_map[(int)REG_EBX]       = SCARAB_REG_RBX;
-  reg_compress_map[(int)REG_GBX]       = SCARAB_REG_RBX;
-  reg_compress_map[(int)REG_EDX]       = SCARAB_REG_RDX;
-  reg_compress_map[(int)REG_GDX]       = SCARAB_REG_RDX;
-  reg_compress_map[(int)REG_ECX]       = SCARAB_REG_RCX;
-  reg_compress_map[(int)REG_GCX]       = SCARAB_REG_RCX;
-  reg_compress_map[(int)REG_EAX]       = SCARAB_REG_RAX;
-  reg_compress_map[(int)REG_GAX]       = SCARAB_REG_RAX;
-  reg_compress_map[(int)REG_GR_LAST]   = SCARAB_REG_RAX;
-  reg_compress_map[(int)REG_SEG_BASE]  = SCARAB_REG_CS;
-  reg_compress_map[(int)REG_SEG_CS]    = SCARAB_REG_CS;
-  reg_compress_map[(int)REG_SEG_SS]    = SCARAB_REG_SS;
-  reg_compress_map[(int)REG_SEG_DS]    = SCARAB_REG_DS;
-  reg_compress_map[(int)REG_SEG_ES]    = SCARAB_REG_ES;
-  reg_compress_map[(int)REG_SEG_FS]    = SCARAB_REG_FS;
-  reg_compress_map[(int)REG_SEG_GS]    = SCARAB_REG_GS;
-  reg_compress_map[(int)REG_SEG_LAST]  = SCARAB_REG_GS;
+//TODO: extract displacement information
+vector<PIN_MEM_ACCESS_INFO> compute_mem_access_infos(
+                        const CONTEXT* ctxt, gather_scatter_info* info) {
+  info->verify_fields_for_mem_access_info_generation();
+
+  vector<PIN_MEM_ACCESS_INFO> mem_access_infos;
+  ADDRINT base_addr_contribution = compute_base_reg_addr_contribution(ctxt,
+                                                                      info);
+  PIN_MEMOP_ENUM memop_type      = type_to_PIN_MEMOP_ENUM(info);
+
+  PIN_REGISTER vector_index_reg_val_buf;
+  assert(reg_xed_to_pin_map.find(info->get_index_reg()) !=
+         reg_xed_to_pin_map.end());
+  PIN_GetContextRegval(ctxt, reg_xed_to_pin_map[info->get_index_reg()],
+                       (UINT8*)&vector_index_reg_val_buf);
+  PIN_REGISTER mask_reg_val_buf;
+  assert(reg_xed_to_pin_map.find(info->get_mask_reg()) !=
+         reg_xed_to_pin_map.end());
+  PIN_GetContextRegval(ctxt, reg_xed_to_pin_map[info->get_mask_reg()],
+                       (UINT8*)&mask_reg_val_buf);
+  for(UINT32 lane_id = 0; lane_id < info->get_num_mem_ops(); lane_id++) {
+    ADDRDELTA index_val = compute_base_index_addr_contribution(
+                                    vector_index_reg_val_buf, lane_id, info);
+    ADDRINT final_addr = base_addr_contribution + (index_val *
+                                                   info->get_scale())
+                       + info->get_displacement();
+    bool                mask_on = extract_mask_on(mask_reg_val_buf, lane_id,
+                                                  info);
+    PIN_MEM_ACCESS_INFO access_info = {.memoryAddress = final_addr,
+                                       .memopType     = memop_type,
+                                       .bytesAccessed =
+                                       info->get_data_lane_width_bytes(),
+                                       .maskOn        = mask_on};
+
+    mem_access_infos.push_back(access_info);
+  }
+
+  return mem_access_infos;
+}
+
+ADDRDELTA compute_base_reg_addr_contribution(const CONTEXT* ctxt,
+                                             gather_scatter_info* info) {
+  ADDRDELTA base_addr_contribution = 0;
+  if(XED_REG_valid(info->get_base_reg())) {
+    PIN_REGISTER buf;
+    ASSERTX(reg_xed_to_pin_map.find(info->get_base_reg()) !=
+            reg_xed_to_pin_map.end());
+    PIN_GetContextRegval(ctxt, reg_xed_to_pin_map[info->get_base_reg()],
+                         (UINT8*)&buf);
+    // need to do this to make sure a 32-bit base register holding a negative
+    // value is properly sign-extended into a 64-bit ADDRDELTA value
+    if(XED_REG_is_gr32(info->get_base_reg())) {
+      base_addr_contribution = buf.s_dword[0];
+    } else if(XED_REG_is_gr64(info->get_base_reg())) {
+      base_addr_contribution = buf.s_qword[0];
+    } else {
+      ASSERTX(false);
+    }
+  }
+  return base_addr_contribution;
+}
+
+ADDRDELTA compute_base_index_addr_contribution(
+            const PIN_REGISTER& vector_index_reg_val, const UINT32 lane_id,
+                                               gather_scatter_info* info) {
+  ADDRDELTA index_val;
+  switch(info->get_index_lane_width_bytes()) {
+    case 4:
+      index_val = vector_index_reg_val.s_dword[lane_id];
+      break;
+    case 8:
+      index_val = vector_index_reg_val.s_qword[lane_id];
+      break;
+    default:
+      ASSERTX(false);
+      break;
+  }
+  return index_val;
+}
+
+PIN_MEMOP_ENUM type_to_PIN_MEMOP_ENUM(gather_scatter_info* info) {
+   switch(info->get_type()) {
+   case gather_scatter_info::GATHER:
+      return PIN_MEMOP_LOAD;
+    case gather_scatter_info::SCATTER:
+      return PIN_MEMOP_STORE;
+    default:
+      ASSERTX(false);
+      return PIN_MEMOP_LOAD;
+  }
+}
+
+bool extract_mask_on(const PIN_REGISTER& mask_reg_val_buf,
+                     const UINT32 lane_id, gather_scatter_info* info) {
+  bool   mask_on  = false;
+  UINT64 msb_mask = ((UINT64)1) << (info->get_data_lane_width_bytes() * 8 - 1);
+
+  switch(info->get_mask_reg_type()) {
+    case gather_scatter_info::K:
+      mask_on = (mask_reg_val_buf.word[0] & (1 << lane_id));
+      break;
+    case gather_scatter_info::XYMM:
+      // Conditionality is specified by the most significant bit of each data
+      // element of the mask register. The width of data element in the
+      // destination register and mask register are identical.
+      switch(info->get_data_lane_width_bytes()) {
+        case 4:
+          mask_on = (mask_reg_val_buf.dword[lane_id] & msb_mask);
+          break;
+
+        case 8:
+          mask_on = (mask_reg_val_buf.qword[lane_id] & msb_mask);
+          break;
+
+        default:
+          ASSERT(false, "expecting data lane width to be 4 or 8 bytes");
+          break;
+      }
+      break;
+    default:
+      ASSERTX(false);
+      break;
+  }
+  return mask_on;
+}
+
+void init_reg_xed_to_pin_map() { 
+  reg_xed_to_pin_map[XED_REG_INVALID]        = REG_INVALID_;
+  reg_xed_to_pin_map[XED_REG_RDI]       = REG_RDI;
+  reg_xed_to_pin_map[XED_REG_EDI]       = REG_EDI;
+  reg_xed_to_pin_map[XED_REG_ESI]       = REG_ESI;
+  reg_xed_to_pin_map[XED_REG_RSI]       = REG_RSI;
+  reg_xed_to_pin_map[XED_REG_EBP]       = REG_EBP;
+  reg_xed_to_pin_map[XED_REG_RBP]       = REG_RBP;
+  reg_xed_to_pin_map[XED_REG_ESP]       = REG_ESP;
+  reg_xed_to_pin_map[XED_REG_RSP]       = REG_RSP;
+  reg_xed_to_pin_map[XED_REG_EBX]       = REG_EBX;
+  reg_xed_to_pin_map[XED_REG_RBX]       = REG_RBX;
+  reg_xed_to_pin_map[XED_REG_EDX]       = REG_EDX;
+  reg_xed_to_pin_map[XED_REG_RDX]       = REG_RDX;
+  reg_xed_to_pin_map[XED_REG_ECX]       = REG_ECX;
+  reg_xed_to_pin_map[XED_REG_RCX]       = REG_RCX;
+  reg_xed_to_pin_map[XED_REG_EAX]       = REG_EAX;
+  reg_xed_to_pin_map[XED_REG_RAX]       = REG_RAX;
+  reg_xed_to_pin_map[XED_REG_R8]      = REG_R8;
+  reg_xed_to_pin_map[XED_REG_R9]      = REG_R9;
+  reg_xed_to_pin_map[XED_REG_R10]     = REG_R10;
+  reg_xed_to_pin_map[XED_REG_R11]     = REG_R11;
+  reg_xed_to_pin_map[XED_REG_R12]     = REG_R12;
+  reg_xed_to_pin_map[XED_REG_R13]     = REG_R13;
+  reg_xed_to_pin_map[XED_REG_R14]     = REG_R14;
+  reg_xed_to_pin_map[XED_REG_R15]     = REG_R15;
+
+  /*
+  //  reg_xed_to_pin_map[XED_REG_GR_LAST]   = REG_RAX;
+  reg_xed_to_pin_map[XED_REG_FSBASE]  = REG_CS;
+  //todo: Not sure about the next
+  reg_xed_to_pin_map[XED_REG_GSBASE]  = REG_CS;
+  reg_xed_to_pin_map[XED_REG_CS]    = REG_CS;
+  reg_xed_to_pin_map[XED_REG_SS]    = REG_SS;
+  reg_xed_to_pin_map[XED_REG_DS]    = REG_DS;
+  reg_xed_to_pin_map[XED_REG_ES]    = REG_ES;
+  reg_xed_to_pin_map[XED_REG_FS]    = REG_FS;
+  reg_xed_to_pin_map[XED_REG_GS]    = REG_GS;
+  //reg_xed_to_pin_map[XED_REG_SEG_LAST]  = REG_GS;
   // Treating any flag dependency as ZPS because we could not
   // get finer grain dependicies from PIN
-  reg_compress_map[(int)REG_EFLAGS]   = SCARAB_REG_ZPS;
-  reg_compress_map[(int)REG_GFLAGS]   = SCARAB_REG_ZPS;
-  reg_compress_map[(int)REG_EIP]      = SCARAB_REG_RIP;
-  reg_compress_map[(int)REG_INST_PTR] = SCARAB_REG_RIP;
-  reg_compress_map[(int)REG_AL]       = SCARAB_REG_RAX;
-  reg_compress_map[(int)REG_AH]       = SCARAB_REG_RAX;
-  reg_compress_map[(int)REG_AX]       = SCARAB_REG_RAX;
-  reg_compress_map[(int)REG_CL]       = SCARAB_REG_RCX;
-  reg_compress_map[(int)REG_CH]       = SCARAB_REG_RCX;
-  reg_compress_map[(int)REG_CX]       = SCARAB_REG_RCX;
-  reg_compress_map[(int)REG_DL]       = SCARAB_REG_RDX;
-  reg_compress_map[(int)REG_DH]       = SCARAB_REG_RDX;
-  reg_compress_map[(int)REG_DX]       = SCARAB_REG_RDX;
-  reg_compress_map[(int)REG_BL]       = SCARAB_REG_RBX;
-  reg_compress_map[(int)REG_BH]       = SCARAB_REG_RBX;
-  reg_compress_map[(int)REG_BX]       = SCARAB_REG_RBX;
-  reg_compress_map[(int)REG_BP]       = SCARAB_REG_RBX;
-  reg_compress_map[(int)REG_SI]       = SCARAB_REG_RSI;
-  reg_compress_map[(int)REG_DI]       = SCARAB_REG_RDI;
-  reg_compress_map[(int)REG_SP]       = SCARAB_REG_RSP;
-  reg_compress_map[(int)REG_FLAGS]    = SCARAB_REG_ZPS;
-  reg_compress_map[(int)REG_IP]       = SCARAB_REG_RIP;
-  reg_compress_map[(int)REG_MM_BASE]  = SCARAB_REG_ZMM0;
-  reg_compress_map[(int)REG_MM0]      = SCARAB_REG_ZMM0;
-  reg_compress_map[(int)REG_MM1]      = SCARAB_REG_ZMM1;
-  reg_compress_map[(int)REG_MM2]      = SCARAB_REG_ZMM2;
-  reg_compress_map[(int)REG_MM3]      = SCARAB_REG_ZMM3;
-  reg_compress_map[(int)REG_MM4]      = SCARAB_REG_ZMM4;
-  reg_compress_map[(int)REG_MM5]      = SCARAB_REG_ZMM5;
-  reg_compress_map[(int)REG_MM6]      = SCARAB_REG_ZMM6;
-  reg_compress_map[(int)REG_MM7]      = SCARAB_REG_ZMM7;
-  reg_compress_map[(int)REG_MM_LAST]  = SCARAB_REG_ZMM7;
+  reg_xed_to_pin_map[XED_REG_EFLAGS]   = REG_ZPS;
+  reg_xed_to_pin_map[XED_REG_RFLAGS]   = REG_ZPS;
+  reg_xed_to_pin_map[XED_REG_EIP]      = REG_RIP;
+  reg_xed_to_pin_map[XED_REG_RIP] = REG_RIP;
+  reg_xed_to_pin_map[XED_REG_AL]       = REG_RAX;
+  reg_xed_to_pin_map[XED_REG_AH]       = REG_RAX;
+  reg_xed_to_pin_map[XED_REG_AX]       = REG_RAX;
+  reg_xed_to_pin_map[XED_REG_CL]       = REG_RCX;
+  reg_xed_to_pin_map[XED_REG_CH]       = REG_RCX;
+  reg_xed_to_pin_map[XED_REG_CX]       = REG_RCX;
+  reg_xed_to_pin_map[XED_REG_DL]       = REG_RDX;
+  reg_xed_to_pin_map[XED_REG_DH]       = REG_RDX;
+  reg_xed_to_pin_map[XED_REG_DX]       = REG_RDX;
+  reg_xed_to_pin_map[XED_REG_BL]       = REG_RBX;
+  reg_xed_to_pin_map[XED_REG_BH]       = REG_RBX;
+  reg_xed_to_pin_map[XED_REG_BX]       = REG_RBX;
+  reg_xed_to_pin_map[XED_REG_BP]       = REG_RBX;
+  reg_xed_to_pin_map[XED_REG_SI]       = REG_RSI;
+  reg_xed_to_pin_map[XED_REG_DI]       = REG_RDI;
+  reg_xed_to_pin_map[XED_REG_SP]       = REG_RSP;
+  reg_xed_to_pin_map[XED_REG_FLAGS]    = REG_ZPS;
+  reg_xed_to_pin_map[XED_REG_IP]       = REG_RIP;
+  reg_xed_to_pin_map[XED_REG_MMX_FIRST]  = REG_ZMM0;
+  reg_xed_to_pin_map[XED_REG_MMX0]      = REG_ZMM0;
+  reg_xed_to_pin_map[XED_REG_MMX1]      = REG_ZMM1;
+  reg_xed_to_pin_map[XED_REG_MMX2]      = REG_ZMM2;
+  reg_xed_to_pin_map[XED_REG_MMX3]      = REG_ZMM3;
+  reg_xed_to_pin_map[XED_REG_MMX4]      = REG_ZMM4;
+  reg_xed_to_pin_map[XED_REG_MMX5]      = REG_ZMM5;
+  reg_xed_to_pin_map[XED_REG_MMX6]      = REG_ZMM6;
+  reg_xed_to_pin_map[XED_REG_MMX7]      = REG_ZMM7;
+  reg_xed_to_pin_map[XED_REG_MMX_LAST]  = REG_ZMM7;
 
-  reg_compress_map[(int)REG_XMM_BASE]        = SCARAB_REG_ZMM0;
-  reg_compress_map[(int)REG_XMM0]            = SCARAB_REG_ZMM0;
-  reg_compress_map[(int)REG_XMM1]            = SCARAB_REG_ZMM1;
-  reg_compress_map[(int)REG_XMM2]            = SCARAB_REG_ZMM2;
-  reg_compress_map[(int)REG_XMM3]            = SCARAB_REG_ZMM3;
-  reg_compress_map[(int)REG_XMM4]            = SCARAB_REG_ZMM4;
-  reg_compress_map[(int)REG_XMM5]            = SCARAB_REG_ZMM5;
-  reg_compress_map[(int)REG_XMM6]            = SCARAB_REG_ZMM6;
-  reg_compress_map[(int)REG_XMM7]            = SCARAB_REG_ZMM7;
-  reg_compress_map[(int)REG_XMM_SSE_LAST]    = SCARAB_REG_ZMM7;
-  reg_compress_map[(int)REG_XMM_AVX_LAST]    = SCARAB_REG_ZMM7;
-  reg_compress_map[(int)REG_XMM_AVX512_LAST] = SCARAB_REG_ZMM7;
-  reg_compress_map[(int)REG_XMM_LAST]        = SCARAB_REG_ZMM7;
+  reg_xed_to_pin_map[XED_REG_XMM_FIRST]       = REG_ZMM0;
+  reg_xed_to_pin_map[XED_REG_XMM0]            = REG_ZMM0;
+  reg_xed_to_pin_map[XED_REG_XMM1]            = REG_ZMM1;
+  reg_xed_to_pin_map[XED_REG_XMM2]            = REG_ZMM2;
+  reg_xed_to_pin_map[XED_REG_XMM3]            = REG_ZMM3;
+  reg_xed_to_pin_map[XED_REG_XMM4]            = REG_ZMM4;
+  reg_xed_to_pin_map[XED_REG_XMM5]            = REG_ZMM5;
+  reg_xed_to_pin_map[XED_REG_XMM6]            = REG_ZMM6;
+  reg_xed_to_pin_map[XED_REG_XMM7]            = REG_ZMM7;
+  //reg_xed_to_pin_map[XED_REG_XMM_SSE_LAST]    = REG_ZMM7;
+  //reg_xed_to_pin_map[XED_REG_XMM_AVX_LAST]    = REG_ZMM7;
+  //reg_xed_to_pin_map[XED_REG_XMM_AVX512_LAST] = REG_ZMM7;
+  reg_xed_to_pin_map[XED_REG_XMM_LAST]        = REG_ZMM7;
 
-  reg_compress_map[(int)REG_YMM_BASE]        = SCARAB_REG_ZMM0;
-  reg_compress_map[(int)REG_YMM0]            = SCARAB_REG_ZMM0;
-  reg_compress_map[(int)REG_YMM1]            = SCARAB_REG_ZMM1;
-  reg_compress_map[(int)REG_YMM2]            = SCARAB_REG_ZMM2;
-  reg_compress_map[(int)REG_YMM3]            = SCARAB_REG_ZMM3;
-  reg_compress_map[(int)REG_YMM4]            = SCARAB_REG_ZMM4;
-  reg_compress_map[(int)REG_YMM5]            = SCARAB_REG_ZMM5;
-  reg_compress_map[(int)REG_YMM6]            = SCARAB_REG_ZMM6;
-  reg_compress_map[(int)REG_YMM7]            = SCARAB_REG_ZMM7;
-  reg_compress_map[(int)REG_YMM_AVX_LAST]    = SCARAB_REG_ZMM7;
-  reg_compress_map[(int)REG_YMM_AVX512_LAST] = SCARAB_REG_ZMM7;
-  reg_compress_map[(int)REG_YMM_LAST]        = SCARAB_REG_ZMM7;
+  reg_xed_to_pin_map[XED_REG_YMM_FIRST]        = REG_ZMM0;
+  reg_xed_to_pin_map[XED_REG_YMM0]            = REG_ZMM0;
+  reg_xed_to_pin_map[XED_REG_YMM1]            = REG_ZMM1;
+  reg_xed_to_pin_map[XED_REG_YMM2]            = REG_ZMM2;
+  reg_xed_to_pin_map[XED_REG_YMM3]            = REG_ZMM3;
+  reg_xed_to_pin_map[XED_REG_YMM4]            = REG_ZMM4;
+  reg_xed_to_pin_map[XED_REG_YMM5]            = REG_ZMM5;
+  reg_xed_to_pin_map[XED_REG_YMM6]            = REG_ZMM6;
+  reg_xed_to_pin_map[XED_REG_YMM7]            = REG_ZMM7;
+  //reg_xed_to_pin_map[XED_REG_YMM_AVX_LAST]    = REG_ZMM7;
+  //reg_xed_to_pin_map[XED_REG_YMM_AVX512_LAST] = REG_ZMM7;
+  reg_xed_to_pin_map[XED_REG_YMM_LAST]        = REG_ZMM7;
 
-  reg_compress_map[(int)REG_ZMM_BASE]              = SCARAB_REG_ZMM0;
-  reg_compress_map[(int)REG_ZMM0]                  = SCARAB_REG_ZMM0;
-  reg_compress_map[(int)REG_ZMM1]                  = SCARAB_REG_ZMM1;
-  reg_compress_map[(int)REG_ZMM2]                  = SCARAB_REG_ZMM2;
-  reg_compress_map[(int)REG_ZMM3]                  = SCARAB_REG_ZMM3;
-  reg_compress_map[(int)REG_ZMM4]                  = SCARAB_REG_ZMM4;
-  reg_compress_map[(int)REG_ZMM5]                  = SCARAB_REG_ZMM5;
-  reg_compress_map[(int)REG_ZMM6]                  = SCARAB_REG_ZMM6;
-  reg_compress_map[(int)REG_ZMM7]                  = SCARAB_REG_ZMM7;
-  reg_compress_map[(int)REG_ZMM_AVX512_SPLIT_LAST] = SCARAB_REG_ZMM7;
-  reg_compress_map[(int)REG_ZMM_AVX512_LAST]       = SCARAB_REG_ZMM7;
-  reg_compress_map[(int)REG_ZMM_LAST]              = SCARAB_REG_ZMM7;
+  reg_xed_to_pin_map[XED_REG_ZMM_FIRST]              = REG_ZMM0;
+  reg_xed_to_pin_map[XED_REG_ZMM0]                  = REG_ZMM0;
+  reg_xed_to_pin_map[XED_REG_ZMM1]                  = REG_ZMM1;
+  reg_xed_to_pin_map[XED_REG_ZMM2]                  = REG_ZMM2;
+  reg_xed_to_pin_map[XED_REG_ZMM3]                  = REG_ZMM3;
+  reg_xed_to_pin_map[XED_REG_ZMM4]                  = REG_ZMM4;
+  reg_xed_to_pin_map[XED_REG_ZMM5]                  = REG_ZMM5;
+  reg_xed_to_pin_map[XED_REG_ZMM6]                  = REG_ZMM6;
+  reg_xed_to_pin_map[XED_REG_ZMM7]                  = REG_ZMM7;
+  //reg_xed_to_pin_map[XED_REG_ZMM_AVX512_SPLIT_LAST] = REG_ZMM7;
+  //reg_xed_to_pin_map[XED_REG_ZMM_AVX512_LAST]       = REG_ZMM7;
+  reg_xed_to_pin_map[XED_REG_ZMM_LAST]              = REG_ZMM7;
 
-  reg_compress_map[(int)REG_K_BASE]             = SCARAB_REG_K0;
-  reg_compress_map[(int)REG_IMPLICIT_FULL_MASK] = SCARAB_REG_K0;
-  reg_compress_map[(int)REG_K0]                 = SCARAB_REG_K0;
-  reg_compress_map[(int)REG_K1]                 = SCARAB_REG_K1;
-  reg_compress_map[(int)REG_K2]                 = SCARAB_REG_K2;
-  reg_compress_map[(int)REG_K3]                 = SCARAB_REG_K3;
-  reg_compress_map[(int)REG_K4]                 = SCARAB_REG_K4;
-  reg_compress_map[(int)REG_K5]                 = SCARAB_REG_K5;
-  reg_compress_map[(int)REG_K6]                 = SCARAB_REG_K6;
-  reg_compress_map[(int)REG_K7]                 = SCARAB_REG_K7;
-  reg_compress_map[(int)REG_K_LAST]             = SCARAB_REG_K7;
+  //reg_xed_to_pin_map[XED_REG_MASK_FIRST]             = REG_K0;
+  //reg_xed_to_pin_map[XED_REG_IMPLICIT_FULL_MASK] = REG_K0;
+  reg_xed_to_pin_map[XED_REG_K0]                 = REG_K0;
+  reg_xed_to_pin_map[XED_REG_K1]                 = REG_K1;
+  reg_xed_to_pin_map[XED_REG_K2]                 = REG_K2;
+  reg_xed_to_pin_map[XED_REG_K3]                 = REG_K3;
+  reg_xed_to_pin_map[XED_REG_K4]                 = REG_K4;
+  reg_xed_to_pin_map[XED_REG_K5]                 = REG_K5;
+  reg_xed_to_pin_map[XED_REG_K6]                 = REG_K6;
+  reg_xed_to_pin_map[XED_REG_K7]                 = REG_K7;
+  //reg_xed_to_pin_map[XED_REG_MASK_LAST]             = REG_K7;
 
-  reg_compress_map[(int)REG_MXCSR]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_MXCSRMASK] = SCARAB_REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_MXCSR]     = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_MXCSRMASK] = REG_OTHER;
 
-  reg_compress_map[(int)REG_FPST_BASE]     = SCARAB_REG_FPCW;
-  reg_compress_map[(int)REG_FPSTATUS_BASE] = SCARAB_REG_FPCW;
-  reg_compress_map[(int)REG_FPCW]          = SCARAB_REG_FPCW;
-  reg_compress_map[(int)REG_FPSW]          = SCARAB_REG_FPST;
-  reg_compress_map[(int)REG_FPTAG]         = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_FPIP_OFF]      = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_FPIP_SEL]      = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_FPOPCODE]      = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_FPDP_OFF]      = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_FPDP_SEL]      = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_FPSTATUS_LAST] = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_FPTAG_FULL]    = SCARAB_REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_X87CONTROL] = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_X87STATUS] = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_X87TAG] = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_X87PUSH] = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_X87POP] = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_X87POP2] = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_X87OPCODE] = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_X87LASTCS] = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_X87LASTIP] = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_X87LASTDS] = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_X87LASTDP] = REG_OTHER;
 
-  reg_compress_map[(int)REG_ST_BASE]   = SCARAB_REG_FP0;
-  reg_compress_map[(int)REG_ST0]       = SCARAB_REG_FP0;
-  reg_compress_map[(int)REG_ST1]       = SCARAB_REG_FP1;
-  reg_compress_map[(int)REG_ST2]       = SCARAB_REG_FP2;
-  reg_compress_map[(int)REG_ST3]       = SCARAB_REG_FP3;
-  reg_compress_map[(int)REG_ST4]       = SCARAB_REG_FP4;
-  reg_compress_map[(int)REG_ST5]       = SCARAB_REG_FP5;
-  reg_compress_map[(int)REG_ST6]       = SCARAB_REG_FP6;
-  reg_compress_map[(int)REG_ST7]       = SCARAB_REG_FP7;
-  reg_compress_map[(int)REG_ST_LAST]   = SCARAB_REG_FP7;
-  reg_compress_map[(int)REG_FPST_LAST] = SCARAB_REG_FP7;
+  //reg_xed_to_pin_map[XED_REG_FPST_BASE]     = REG_FPCW;
+  //reg_xed_to_pin_map[XED_REG_FPSTATUS_BASE] = REG_FPCW;
+  //reg_xed_to_pin_map[XED_REG_FPCW]          = REG_FPCW;
+  //reg_xed_to_pin_map[XED_REG_FPSW]          = REG_FPST;
+  //reg_xed_to_pin_map[XED_REG_FPTAG]         = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_FPIP_OFF]      = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_FPIP_SEL]      = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_FPOPCODE]      = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_FPDP_OFF]      = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_FPDP_SEL]      = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_FPSTATUS_LAST] = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_FPTAG_FULL]    = REG_OTHER;
 
-  reg_compress_map[(int)REG_DR_BASE] = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_DR0]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_DR1]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_DR2]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_DR3]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_DR4]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_DR5]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_DR6]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_DR7]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_DR_LAST] = SCARAB_REG_OTHER;
+  //  reg_xed_to_pin_map[XED_REG_ST_BASE]   = REG_FP0;
+  reg_xed_to_pin_map[XED_REG_ST0]       = REG_FP0;
+  reg_xed_to_pin_map[XED_REG_ST1]       = REG_FP1;
+  reg_xed_to_pin_map[XED_REG_ST2]       = REG_FP2;
+  reg_xed_to_pin_map[XED_REG_ST3]       = REG_FP3;
+  reg_xed_to_pin_map[XED_REG_ST4]       = REG_FP4;
+  reg_xed_to_pin_map[XED_REG_ST5]       = REG_FP5;
+  reg_xed_to_pin_map[XED_REG_ST6]       = REG_FP6;
+  reg_xed_to_pin_map[XED_REG_ST7]       = REG_FP7;
+  //reg_xed_to_pin_map[XED_REG_ST_LAST]   = REG_FP7;
+  //reg_xed_to_pin_map[XED_REG_FPST_LAST] = REG_FP7;
 
-  reg_compress_map[(int)REG_CR_BASE] = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_CR0]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_CR1]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_CR2]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_CR3]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_CR4]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_CR_LAST] = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_TSSR]    = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_LDTR]    = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_TR_BASE] = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_TR]      = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_TR3]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_TR4]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_TR5]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_TR6]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_TR7]     = SCARAB_REG_OTHER;
-  reg_compress_map[(int)REG_TR_LAST] = SCARAB_REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_DR_BASE] = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_DR0]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_DR1]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_DR2]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_DR3]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_DR4]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_DR5]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_DR6]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_DR7]     = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_DR_LAST] = REG_OTHER;
 
-#if defined(TARGET_IA32E)
-  reg_compress_map[(int)REG_RDI]     = SCARAB_REG_RDI;
-  reg_compress_map[(int)REG_RSI]     = SCARAB_REG_RSI;
-  reg_compress_map[(int)REG_RBP]     = SCARAB_REG_RBP;
-  reg_compress_map[(int)REG_RSP]     = SCARAB_REG_RSP;
-  reg_compress_map[(int)REG_RBX]     = SCARAB_REG_RBX;
-  reg_compress_map[(int)REG_RDX]     = SCARAB_REG_RDX;
-  reg_compress_map[(int)REG_RCX]     = SCARAB_REG_RCX;
-  reg_compress_map[(int)REG_RAX]     = SCARAB_REG_RAX;
-  reg_compress_map[(int)REG_R8]      = SCARAB_REG_R8;
-  reg_compress_map[(int)REG_R9]      = SCARAB_REG_R9;
-  reg_compress_map[(int)REG_R10]     = SCARAB_REG_R10;
-  reg_compress_map[(int)REG_R11]     = SCARAB_REG_R11;
-  reg_compress_map[(int)REG_R12]     = SCARAB_REG_R12;
-  reg_compress_map[(int)REG_R13]     = SCARAB_REG_R13;
-  reg_compress_map[(int)REG_R14]     = SCARAB_REG_R14;
-  reg_compress_map[(int)REG_R15]     = SCARAB_REG_R15;
-  reg_compress_map[(int)REG_GR_LAST] = SCARAB_REG_R15;
-  reg_compress_map[(int)REG_RFLAGS]  = SCARAB_REG_ZPS;
-  reg_compress_map[(int)REG_RIP]     = SCARAB_REG_RIP;
+  //reg_xed_to_pin_map[XED_REG_CR_BASE] = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_TSC]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_TSCAUX]  = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_XCR0]    = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR0]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR1]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR2]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR3]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR4]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR5]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR6]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR7]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR8]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR9]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR10]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR11]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR12]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR13]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR14]     = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_CR15]     = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_CR_LAST] = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_TSSR]    = REG_OTHER;
+  reg_xed_to_pin_map[XED_REG_LDTR]    = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_TR_BASE] = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_TR]      = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_TR3]     = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_TR4]     = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_TR5]     = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_TR6]     = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_TR7]     = REG_OTHER;
+  //reg_xed_to_pin_map[XED_REG_TR_LAST] = REG_OTHER;
 
-  reg_compress_map[(int)REG_DIL]  = SCARAB_REG_RDI;
-  reg_compress_map[(int)REG_SIL]  = SCARAB_REG_RSI;
-  reg_compress_map[(int)REG_BPL]  = SCARAB_REG_RBP;
-  reg_compress_map[(int)REG_SPL]  = SCARAB_REG_RSP;
-  reg_compress_map[(int)REG_R8B]  = SCARAB_REG_R8;
-  reg_compress_map[(int)REG_R8W]  = SCARAB_REG_R8;
-  reg_compress_map[(int)REG_R8D]  = SCARAB_REG_R8;
-  reg_compress_map[(int)REG_R9B]  = SCARAB_REG_R9;
-  reg_compress_map[(int)REG_R9W]  = SCARAB_REG_R9;
-  reg_compress_map[(int)REG_R9D]  = SCARAB_REG_R9;
-  reg_compress_map[(int)REG_R10B] = SCARAB_REG_R10;
-  reg_compress_map[(int)REG_R10W] = SCARAB_REG_R10;
-  reg_compress_map[(int)REG_R10D] = SCARAB_REG_R10;
-  reg_compress_map[(int)REG_R11B] = SCARAB_REG_R11;
-  reg_compress_map[(int)REG_R11W] = SCARAB_REG_R11;
-  reg_compress_map[(int)REG_R11D] = SCARAB_REG_R11;
-  reg_compress_map[(int)REG_R12B] = SCARAB_REG_R12;
-  reg_compress_map[(int)REG_R12W] = SCARAB_REG_R12;
-  reg_compress_map[(int)REG_R12D] = SCARAB_REG_R12;
-  reg_compress_map[(int)REG_R13B] = SCARAB_REG_R13;
-  reg_compress_map[(int)REG_R13W] = SCARAB_REG_R13;
-  reg_compress_map[(int)REG_R13D] = SCARAB_REG_R13;
-  reg_compress_map[(int)REG_R14B] = SCARAB_REG_R14;
-  reg_compress_map[(int)REG_R14W] = SCARAB_REG_R14;
-  reg_compress_map[(int)REG_R14D] = SCARAB_REG_R14;
-  reg_compress_map[(int)REG_R15B] = SCARAB_REG_R15;
-  reg_compress_map[(int)REG_R15W] = SCARAB_REG_R15;
-  reg_compress_map[(int)REG_R15D] = SCARAB_REG_R15;
+  reg_xed_to_pin_map[XED_REG_STACKPUSH] = REG_RSP;
+  reg_xed_to_pin_map[XED_REG_STACKPOP] = REG_RSP;
+  reg_xed_to_pin_map[XED_REG_RDI]     = REG_RDI;
+  reg_xed_to_pin_map[XED_REG_RSI]     = REG_RSI;
+  reg_xed_to_pin_map[XED_REG_RBP]     = REG_RBP;
+  reg_xed_to_pin_map[XED_REG_RSP]     = REG_RSP;
+  reg_xed_to_pin_map[XED_REG_RBX]     = REG_RBX;
+  reg_xed_to_pin_map[XED_REG_RDX]     = REG_RDX;
+  reg_xed_to_pin_map[XED_REG_RCX]     = REG_RCX;
+  reg_xed_to_pin_map[XED_REG_RAX]     = REG_RAX;
+  reg_xed_to_pin_map[XED_REG_R8]      = REG_R8;
+  reg_xed_to_pin_map[XED_REG_R9]      = REG_R9;
+  reg_xed_to_pin_map[XED_REG_R10]     = REG_R10;
+  reg_xed_to_pin_map[XED_REG_R11]     = REG_R11;
+  reg_xed_to_pin_map[XED_REG_R12]     = REG_R12;
+  reg_xed_to_pin_map[XED_REG_R13]     = REG_R13;
+  reg_xed_to_pin_map[XED_REG_R14]     = REG_R14;
+  reg_xed_to_pin_map[XED_REG_R15]     = REG_R15;
+  //reg_xed_to_pin_map[XED_REG_GR_LAST] = REG_R15;
+  reg_xed_to_pin_map[XED_REG_RFLAGS]  = REG_ZPS;
+  reg_xed_to_pin_map[XED_REG_RIP]     = REG_RIP;
 
-  reg_compress_map[(int)REG_XMM8]                  = SCARAB_REG_ZMM8;
-  reg_compress_map[(int)REG_XMM9]                  = SCARAB_REG_ZMM9;
-  reg_compress_map[(int)REG_XMM10]                 = SCARAB_REG_ZMM10;
-  reg_compress_map[(int)REG_XMM11]                 = SCARAB_REG_ZMM11;
-  reg_compress_map[(int)REG_XMM12]                 = SCARAB_REG_ZMM12;
-  reg_compress_map[(int)REG_XMM13]                 = SCARAB_REG_ZMM13;
-  reg_compress_map[(int)REG_XMM14]                 = SCARAB_REG_ZMM14;
-  reg_compress_map[(int)REG_XMM15]                 = SCARAB_REG_ZMM15;
-  reg_compress_map[(int)REG_XMM_SSE_LAST]          = SCARAB_REG_ZMM15;
-  reg_compress_map[(int)REG_XMM_AVX_LAST]          = SCARAB_REG_ZMM15;
-  reg_compress_map[(int)REG_XMM16]                 = SCARAB_REG_ZMM16;
-  reg_compress_map[(int)REG_XMM_AVX512_HI16_FIRST] = SCARAB_REG_ZMM16;
-  reg_compress_map[(int)REG_XMM17]                 = SCARAB_REG_ZMM17;
-  reg_compress_map[(int)REG_XMM18]                 = SCARAB_REG_ZMM18;
-  reg_compress_map[(int)REG_XMM19]                 = SCARAB_REG_ZMM19;
-  reg_compress_map[(int)REG_XMM20]                 = SCARAB_REG_ZMM20;
-  reg_compress_map[(int)REG_XMM21]                 = SCARAB_REG_ZMM21;
-  reg_compress_map[(int)REG_XMM22]                 = SCARAB_REG_ZMM22;
-  reg_compress_map[(int)REG_XMM23]                 = SCARAB_REG_ZMM23;
-  reg_compress_map[(int)REG_XMM24]                 = SCARAB_REG_ZMM24;
-  reg_compress_map[(int)REG_XMM25]                 = SCARAB_REG_ZMM25;
-  reg_compress_map[(int)REG_XMM26]                 = SCARAB_REG_ZMM26;
-  reg_compress_map[(int)REG_XMM27]                 = SCARAB_REG_ZMM27;
-  reg_compress_map[(int)REG_XMM28]                 = SCARAB_REG_ZMM28;
-  reg_compress_map[(int)REG_XMM29]                 = SCARAB_REG_ZMM29;
-  reg_compress_map[(int)REG_XMM30]                 = SCARAB_REG_ZMM30;
-  reg_compress_map[(int)REG_XMM31]                 = SCARAB_REG_ZMM31;
-  reg_compress_map[(int)REG_XMM_AVX512_HI16_LAST]  = SCARAB_REG_ZMM31;
-  reg_compress_map[(int)REG_XMM_AVX512_LAST]       = SCARAB_REG_ZMM31;
-  reg_compress_map[(int)REG_XMM_LAST]              = SCARAB_REG_ZMM31;
+  reg_xed_to_pin_map[XED_REG_DIL]  = REG_RDI;
+  reg_xed_to_pin_map[XED_REG_SIL]  = REG_RSI;
+  reg_xed_to_pin_map[XED_REG_BPL]  = REG_RBP;
+  reg_xed_to_pin_map[XED_REG_SPL]  = REG_RSP;
+  reg_xed_to_pin_map[XED_REG_R8B]  = REG_R8;
+  reg_xed_to_pin_map[XED_REG_R8W]  = REG_R8;
+  reg_xed_to_pin_map[XED_REG_R8D]  = REG_R8;
+  reg_xed_to_pin_map[XED_REG_R9B]  = REG_R9;
+  reg_xed_to_pin_map[XED_REG_R9W]  = REG_R9;
+  reg_xed_to_pin_map[XED_REG_R9D]  = REG_R9;
+  reg_xed_to_pin_map[XED_REG_R10B] = REG_R10;
+  reg_xed_to_pin_map[XED_REG_R10W] = REG_R10;
+  reg_xed_to_pin_map[XED_REG_R10D] = REG_R10;
+  reg_xed_to_pin_map[XED_REG_R11B] = REG_R11;
+  reg_xed_to_pin_map[XED_REG_R11W] = REG_R11;
+  reg_xed_to_pin_map[XED_REG_R11D] = REG_R11;
+  reg_xed_to_pin_map[XED_REG_R12B] = REG_R12;
+  reg_xed_to_pin_map[XED_REG_R12W] = REG_R12;
+  reg_xed_to_pin_map[XED_REG_R12D] = REG_R12;
+  reg_xed_to_pin_map[XED_REG_R13B] = REG_R13;
+  reg_xed_to_pin_map[XED_REG_R13W] = REG_R13;
+  reg_xed_to_pin_map[XED_REG_R13D] = REG_R13;
+  reg_xed_to_pin_map[XED_REG_R14B] = REG_R14;
+  reg_xed_to_pin_map[XED_REG_R14W] = REG_R14;
+  reg_xed_to_pin_map[XED_REG_R14D] = REG_R14;
+  reg_xed_to_pin_map[XED_REG_R15B] = REG_R15;
+  reg_xed_to_pin_map[XED_REG_R15W] = REG_R15;
+  reg_xed_to_pin_map[XED_REG_R15D] = REG_R15;
 
-  reg_compress_map[(int)REG_YMM8]                  = SCARAB_REG_ZMM8;
-  reg_compress_map[(int)REG_YMM9]                  = SCARAB_REG_ZMM9;
-  reg_compress_map[(int)REG_YMM10]                 = SCARAB_REG_ZMM10;
-  reg_compress_map[(int)REG_YMM11]                 = SCARAB_REG_ZMM11;
-  reg_compress_map[(int)REG_YMM12]                 = SCARAB_REG_ZMM12;
-  reg_compress_map[(int)REG_YMM13]                 = SCARAB_REG_ZMM13;
-  reg_compress_map[(int)REG_YMM14]                 = SCARAB_REG_ZMM14;
-  reg_compress_map[(int)REG_YMM15]                 = SCARAB_REG_ZMM15;
-  reg_compress_map[(int)REG_YMM_AVX_LAST]          = SCARAB_REG_ZMM15;
-  reg_compress_map[(int)REG_YMM16]                 = SCARAB_REG_ZMM16;
-  reg_compress_map[(int)REG_YMM_AVX512_HI16_FIRST] = SCARAB_REG_ZMM16;
-  reg_compress_map[(int)REG_YMM17]                 = SCARAB_REG_ZMM17;
-  reg_compress_map[(int)REG_YMM18]                 = SCARAB_REG_ZMM18;
-  reg_compress_map[(int)REG_YMM19]                 = SCARAB_REG_ZMM19;
-  reg_compress_map[(int)REG_YMM20]                 = SCARAB_REG_ZMM20;
-  reg_compress_map[(int)REG_YMM21]                 = SCARAB_REG_ZMM21;
-  reg_compress_map[(int)REG_YMM22]                 = SCARAB_REG_ZMM22;
-  reg_compress_map[(int)REG_YMM23]                 = SCARAB_REG_ZMM23;
-  reg_compress_map[(int)REG_YMM24]                 = SCARAB_REG_ZMM24;
-  reg_compress_map[(int)REG_YMM25]                 = SCARAB_REG_ZMM25;
-  reg_compress_map[(int)REG_YMM26]                 = SCARAB_REG_ZMM26;
-  reg_compress_map[(int)REG_YMM27]                 = SCARAB_REG_ZMM27;
-  reg_compress_map[(int)REG_YMM28]                 = SCARAB_REG_ZMM28;
-  reg_compress_map[(int)REG_YMM29]                 = SCARAB_REG_ZMM29;
-  reg_compress_map[(int)REG_YMM30]                 = SCARAB_REG_ZMM30;
-  reg_compress_map[(int)REG_YMM31]                 = SCARAB_REG_ZMM31;
-  reg_compress_map[(int)REG_YMM_AVX512_HI16_LAST]  = SCARAB_REG_ZMM31;
-  reg_compress_map[(int)REG_YMM_AVX512_LAST]       = SCARAB_REG_ZMM31;
-  reg_compress_map[(int)REG_YMM_LAST]              = SCARAB_REG_ZMM31;
+  reg_xed_to_pin_map[XED_REG_XMM8]                  = REG_ZMM8;
+  reg_xed_to_pin_map[XED_REG_XMM9]                  = REG_ZMM9;
+  reg_xed_to_pin_map[XED_REG_XMM10]                 = REG_ZMM10;
+  reg_xed_to_pin_map[XED_REG_XMM11]                 = REG_ZMM11;
+  reg_xed_to_pin_map[XED_REG_XMM12]                 = REG_ZMM12;
+  reg_xed_to_pin_map[XED_REG_XMM13]                 = REG_ZMM13;
+  reg_xed_to_pin_map[XED_REG_XMM14]                 = REG_ZMM14;
+  reg_xed_to_pin_map[XED_REG_XMM15]                 = REG_ZMM15;
+  //reg_xed_to_pin_map[XED_REG_XMM_SSE_LAST]          = REG_ZMM15;
+  //reg_xed_to_pin_map[XED_REG_XMM_AVX_LAST]          = REG_ZMM15;
+  reg_xed_to_pin_map[XED_REG_XMM16]                 = REG_ZMM16;
+  //reg_xed_to_pin_map[XED_REG_XMM_AVX512_HI16_FIRST] = REG_ZMM16;
+  reg_xed_to_pin_map[XED_REG_XMM17]                 = REG_ZMM17;
+  reg_xed_to_pin_map[XED_REG_XMM18]                 = REG_ZMM18;
+  reg_xed_to_pin_map[XED_REG_XMM19]                 = REG_ZMM19;
+  reg_xed_to_pin_map[XED_REG_XMM20]                 = REG_ZMM20;
+  reg_xed_to_pin_map[XED_REG_XMM21]                 = REG_ZMM21;
+  reg_xed_to_pin_map[XED_REG_XMM22]                 = REG_ZMM22;
+  reg_xed_to_pin_map[XED_REG_XMM23]                 = REG_ZMM23;
+  reg_xed_to_pin_map[XED_REG_XMM24]                 = REG_ZMM24;
+  reg_xed_to_pin_map[XED_REG_XMM25]                 = REG_ZMM25;
+  reg_xed_to_pin_map[XED_REG_XMM26]                 = REG_ZMM26;
+  reg_xed_to_pin_map[XED_REG_XMM27]                 = REG_ZMM27;
+  reg_xed_to_pin_map[XED_REG_XMM28]                 = REG_ZMM28;
+  reg_xed_to_pin_map[XED_REG_XMM29]                 = REG_ZMM29;
+  reg_xed_to_pin_map[XED_REG_XMM30]                 = REG_ZMM30;
+  reg_xed_to_pin_map[XED_REG_XMM31]                 = REG_ZMM31;
+  //reg_xed_to_pin_map[XED_REG_XMM_AVX512_HI16_LAST]  = REG_ZMM31;
+  //reg_xed_to_pin_map[XED_REG_XMM_AVX512_LAST]       = REG_ZMM31;
+  reg_xed_to_pin_map[XED_REG_XMM_LAST]              = REG_ZMM31;
 
-  reg_compress_map[(int)REG_ZMM8]                  = SCARAB_REG_ZMM8;
-  reg_compress_map[(int)REG_ZMM9]                  = SCARAB_REG_ZMM9;
-  reg_compress_map[(int)REG_ZMM10]                 = SCARAB_REG_ZMM10;
-  reg_compress_map[(int)REG_ZMM11]                 = SCARAB_REG_ZMM11;
-  reg_compress_map[(int)REG_ZMM12]                 = SCARAB_REG_ZMM12;
-  reg_compress_map[(int)REG_ZMM13]                 = SCARAB_REG_ZMM13;
-  reg_compress_map[(int)REG_ZMM14]                 = SCARAB_REG_ZMM14;
-  reg_compress_map[(int)REG_ZMM15]                 = SCARAB_REG_ZMM15;
-  reg_compress_map[(int)REG_ZMM_AVX512_SPLIT_LAST] = SCARAB_REG_ZMM15;
-  reg_compress_map[(int)REG_ZMM16]                 = SCARAB_REG_ZMM16;
-  reg_compress_map[(int)REG_ZMM_AVX512_HI16_FIRST] = SCARAB_REG_ZMM16;
-  reg_compress_map[(int)REG_ZMM17]                 = SCARAB_REG_ZMM17;
-  reg_compress_map[(int)REG_ZMM18]                 = SCARAB_REG_ZMM18;
-  reg_compress_map[(int)REG_ZMM19]                 = SCARAB_REG_ZMM19;
-  reg_compress_map[(int)REG_ZMM20]                 = SCARAB_REG_ZMM20;
-  reg_compress_map[(int)REG_ZMM21]                 = SCARAB_REG_ZMM21;
-  reg_compress_map[(int)REG_ZMM22]                 = SCARAB_REG_ZMM22;
-  reg_compress_map[(int)REG_ZMM23]                 = SCARAB_REG_ZMM23;
-  reg_compress_map[(int)REG_ZMM24]                 = SCARAB_REG_ZMM24;
-  reg_compress_map[(int)REG_ZMM25]                 = SCARAB_REG_ZMM25;
-  reg_compress_map[(int)REG_ZMM26]                 = SCARAB_REG_ZMM26;
-  reg_compress_map[(int)REG_ZMM27]                 = SCARAB_REG_ZMM27;
-  reg_compress_map[(int)REG_ZMM28]                 = SCARAB_REG_ZMM28;
-  reg_compress_map[(int)REG_ZMM29]                 = SCARAB_REG_ZMM29;
-  reg_compress_map[(int)REG_ZMM30]                 = SCARAB_REG_ZMM30;
-  reg_compress_map[(int)REG_ZMM31]                 = SCARAB_REG_ZMM31;
-  reg_compress_map[(int)REG_ZMM_AVX512_HI16_LAST]  = SCARAB_REG_ZMM31;
-  reg_compress_map[(int)REG_ZMM_AVX512_LAST]       = SCARAB_REG_ZMM31;
-  reg_compress_map[(int)REG_ZMM_LAST]              = SCARAB_REG_ZMM31;
-#endif
+  reg_xed_to_pin_map[XED_REG_YMM8]                  = REG_ZMM8;
+  reg_xed_to_pin_map[XED_REG_YMM9]                  = REG_ZMM9;
+  reg_xed_to_pin_map[XED_REG_YMM10]                 = REG_ZMM10;
+  reg_xed_to_pin_map[XED_REG_YMM11]                 = REG_ZMM11;
+  reg_xed_to_pin_map[XED_REG_YMM12]                 = REG_ZMM12;
+  reg_xed_to_pin_map[XED_REG_YMM13]                 = REG_ZMM13;
+  reg_xed_to_pin_map[XED_REG_YMM14]                 = REG_ZMM14;
+  reg_xed_to_pin_map[XED_REG_YMM15]                 = REG_ZMM15;
+  //reg_xed_to_pin_map[XED_REG_YMM_AVX_LAST]          = REG_ZMM15;
+  reg_xed_to_pin_map[XED_REG_YMM16]                 = REG_ZMM16;
+  //reg_xed_to_pin_map[XED_REG_YMM_AVX512_HI16_FIRST] = REG_ZMM16;
+  reg_xed_to_pin_map[XED_REG_YMM17]                 = REG_ZMM17;
+  reg_xed_to_pin_map[XED_REG_YMM18]                 = REG_ZMM18;
+  reg_xed_to_pin_map[XED_REG_YMM19]                 = REG_ZMM19;
+  reg_xed_to_pin_map[XED_REG_YMM20]                 = REG_ZMM20;
+  reg_xed_to_pin_map[XED_REG_YMM21]                 = REG_ZMM21;
+  reg_xed_to_pin_map[XED_REG_YMM22]                 = REG_ZMM22;
+  reg_xed_to_pin_map[XED_REG_YMM23]                 = REG_ZMM23;
+  reg_xed_to_pin_map[XED_REG_YMM24]                 = REG_ZMM24;
+  reg_xed_to_pin_map[XED_REG_YMM25]                 = REG_ZMM25;
+  reg_xed_to_pin_map[XED_REG_YMM26]                 = REG_ZMM26;
+  reg_xed_to_pin_map[XED_REG_YMM27]                 = REG_ZMM27;
+  reg_xed_to_pin_map[XED_REG_YMM28]                 = REG_ZMM28;
+  reg_xed_to_pin_map[XED_REG_YMM29]                 = REG_ZMM29;
+  reg_xed_to_pin_map[XED_REG_YMM30]                 = REG_ZMM30;
+  reg_xed_to_pin_map[XED_REG_YMM31]                 = REG_ZMM31;
+  //reg_xed_to_pin_map[XED_REG_YMM_AVX512_HI16_LAST]  = REG_ZMM31;
+  //reg_xed_to_pin_map[XED_REG_YMM_AVX512_LAST]       = REG_ZMM31;
+  reg_xed_to_pin_map[XED_REG_YMM_LAST]              = REG_ZMM31;
+
+  reg_xed_to_pin_map[XED_REG_ZMM8]                  = REG_ZMM8;
+  reg_xed_to_pin_map[XED_REG_ZMM9]                  = REG_ZMM9;
+  reg_xed_to_pin_map[XED_REG_ZMM10]                 = REG_ZMM10;
+  reg_xed_to_pin_map[XED_REG_ZMM11]                 = REG_ZMM11;
+  reg_xed_to_pin_map[XED_REG_ZMM12]                 = REG_ZMM12;
+  reg_xed_to_pin_map[XED_REG_ZMM13]                 = REG_ZMM13;
+  reg_xed_to_pin_map[XED_REG_ZMM14]                 = REG_ZMM14;
+  reg_xed_to_pin_map[XED_REG_ZMM15]                 = REG_ZMM15;
+  //reg_xed_to_pin_map[XED_REG_ZMM_AVX512_SPLIT_LAST] = REG_ZMM15;
+  reg_xed_to_pin_map[XED_REG_ZMM16]                 = REG_ZMM16;
+  //reg_xed_to_pin_map[XED_REG_ZMM_AVX512_HI16_FIRST] = REG_ZMM16;
+  reg_xed_to_pin_map[XED_REG_ZMM17]                 = REG_ZMM17;
+  reg_xed_to_pin_map[XED_REG_ZMM18]                 = REG_ZMM18;
+  reg_xed_to_pin_map[XED_REG_ZMM19]                 = REG_ZMM19;
+  reg_xed_to_pin_map[XED_REG_ZMM20]                 = REG_ZMM20;
+  reg_xed_to_pin_map[XED_REG_ZMM21]                 = REG_ZMM21;
+  reg_xed_to_pin_map[XED_REG_ZMM22]                 = REG_ZMM22;
+  reg_xed_to_pin_map[XED_REG_ZMM23]                 = REG_ZMM23;
+  reg_xed_to_pin_map[XED_REG_ZMM24]                 = REG_ZMM24;
+  reg_xed_to_pin_map[XED_REG_ZMM25]                 = REG_ZMM25;
+  reg_xed_to_pin_map[XED_REG_ZMM26]                 = REG_ZMM26;
+  reg_xed_to_pin_map[XED_REG_ZMM27]                 = REG_ZMM27;
+  reg_xed_to_pin_map[XED_REG_ZMM28]                 = REG_ZMM28;
+  reg_xed_to_pin_map[XED_REG_ZMM29]                 = REG_ZMM29;
+  reg_xed_to_pin_map[XED_REG_ZMM30]                 = REG_ZMM30;
+  reg_xed_to_pin_map[XED_REG_ZMM31]                 = REG_ZMM31;
+  //reg_xed_to_pin_map[XED_REG_ZMM_AVX512_HI16_LAST]  = REG_ZMM31;
+  //reg_xed_to_pin_map[XED_REG_ZMM_AVX512_LAST]       = REG_ZMM31;
+  reg_xed_to_pin_map[XED_REG_ZMM_LAST]              = REG_ZMM31;
+  */
 };
-
-static void init_pin_opcode_convert(void) {
-  ASSERTX(OP_INV == 0);
-
-  iclass_to_scarab_map[XED_ICLASS_ADC]      = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ADCX]     = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ADC_LOCK] = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ADD]      = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ADDPD]    = {OP_FADD, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ADDPS]    = {OP_FADD, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ADDSD]    = {OP_FADD, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ADDSS]    = {OP_FADD, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ADDSUBPD] = {OP_FADD, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ADDSUBPS] = {OP_FADD, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ADD_LOCK] = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_AND]      = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ANDN]     = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ANDNPD]   = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ANDNPS]   = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ANDPD]    = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ANDPS]    = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_AND_LOCK] = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BLSI]     = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BLSMSK]   = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BLSR]     = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BSF] = {OP_NOTPIPELINED_MEDIUM, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BSR] = {OP_NOTPIPELINED_MEDIUM, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BSWAP]     = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BT]        = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BTC]       = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BTC_LOCK]  = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BTR]       = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BTR_LOCK]  = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BTS]       = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_BTS_LOCK]  = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CALL_FAR]  = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CALL_NEAR] = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CBW]       = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CDQ]       = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CDQE]      = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CLC]       = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CLD]       = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMC]       = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVB]     = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVBE]    = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVL]     = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVLE]    = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVNB]    = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVNBE]   = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVNL]    = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVNLE]   = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVNO]    = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVNP]    = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVNS]    = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVNZ]    = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVO]     = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVP]     = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVS]     = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMOVZ]     = {OP_CMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMP]       = {OP_ICMP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPPD]     = {OP_FCMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPPS]     = {OP_FCMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPSB]     = {OP_ICMP, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPSD]     = {OP_ICMP, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPSD_XMM] = {OP_FCMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPSQ]     = {OP_ICMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPSS]     = {OP_FCMP, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPSW]     = {OP_ICMP, 2, 1, NONE};
-  // TODO: make sure Scarab produces reasonable micro-ops for CMPXCHG.
-  // Also, should not be a Scarab ifetch barrier.
-  iclass_to_scarab_map[XED_ICLASS_CMPXCHG]         = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPXCHG16B]      = {OP_IADD, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPXCHG16B_LOCK] = {OP_IADD, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPXCHG8B]       = {OP_IADD, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPXCHG8B_LOCK]  = {OP_IADD, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CMPXCHG_LOCK]    = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_COMISD]          = {OP_ICMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_COMISS]          = {OP_ICMP, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTDQ2PD]        = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTDQ2PS]        = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTPD2DQ]        = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTPD2PI]        = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTPD2PS]        = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTPI2PD]        = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTPI2PS]        = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTPS2DQ]        = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTPS2PD]        = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTPS2PI]        = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTSD2SI]        = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTSD2SS]        = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTSI2SD]        = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTSI2SS]        = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTSS2SD]        = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTSS2SI]        = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTTPD2DQ]       = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTTPD2PI]       = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTTPS2DQ]       = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTTPS2PI]       = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTTSD2SI]       = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CVTTSS2SI]       = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CPUID]    = {OP_NOTPIPELINED_VERY_SLOW, -1, 1,
-                                            NONE};
-  iclass_to_scarab_map[XED_ICLASS_CQO]      = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CWD]      = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_CWDE]     = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_DEC]      = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_DEC_LOCK] = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_DIV]      = {OP_IDIV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_DIVPD]    = {OP_FDIV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_DIVPS]    = {OP_FDIV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_DIVSD]    = {OP_FDIV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_DIVSS]    = {OP_FDIV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FABS]     = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FADD]     = {OP_FADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FADDP]    = {OP_FADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCHS]     = {OP_LOGIC, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCMOVB]   = {OP_FCMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCMOVBE]  = {OP_FCMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCMOVE]   = {OP_FCMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCMOVNB]  = {OP_FCMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCMOVNBE] = {OP_FCMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCMOVNE]  = {OP_FCMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCMOVNU]  = {OP_FCMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCMOVU]   = {OP_FCMOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCOM]     = {OP_FCMP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCOMI]    = {OP_FCMP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCOMIP]   = {OP_FCMP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCOMP]    = {OP_FCMP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCOMPP]   = {OP_FCMP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FCOS]     = {OP_NOTPIPELINED_VERY_SLOW, 8, 1,
-                                           NONE};
-  iclass_to_scarab_map[XED_ICLASS_FDISI8087_NOP] = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FDIV]          = {OP_FDIV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FDIVP]         = {OP_FDIV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FDIVR]         = {OP_FDIV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FDIVRP]        = {OP_FDIV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FENI8087_NOP]  = {OP_NOP, -1, 1, NONE};
-  // Most FI* opcodes are mapped to FMUL to account for longer latency because
-  // they involve an integer/float convertion AND operate.
-  iclass_to_scarab_map[XED_ICLASS_FIADD]   = {OP_FMUL, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FICOM]   = {OP_FMUL, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FICOMP]  = {OP_FMUL, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FIDIV]   = {OP_FDIV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FIDIVR]  = {OP_FDIV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FILD]    = {OP_FCVT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FIMUL]   = {OP_FMUL, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FINCSTP] = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FIST]    = {OP_FCVT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FISTP]   = {OP_FCVT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FISTTP]  = {OP_FCVT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FISUB]   = {OP_FMUL, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FISUBR]  = {OP_FMUL, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FLD]     = {OP_MOV, -1, 1,
-                                          NONE};  // Potential FMOV
-  iclass_to_scarab_map[XED_ICLASS_FLD1]    = {OP_MOV, -1, 1,
-                                           NONE};  // Potential FMOV
-  iclass_to_scarab_map[XED_ICLASS_FLDCW]   = {OP_NOTPIPELINED_MEDIUM, -1, 1,
-                                            NONE};
-  iclass_to_scarab_map[XED_ICLASS_FLDL2E]  = {OP_MOV, -1, 1,
-                                             NONE};  // Potential FMOV
-  iclass_to_scarab_map[XED_ICLASS_FLDL2T]  = {OP_MOV, -1, 1,
-                                             NONE};  // Potential FMOV
-  iclass_to_scarab_map[XED_ICLASS_FLDLG2]  = {OP_MOV, -1, 1,
-                                             NONE};  // Potential FMOV
-  iclass_to_scarab_map[XED_ICLASS_FLDLN2]  = {OP_MOV, -1, 1,
-                                             NONE};  // Potential FMOV
-  iclass_to_scarab_map[XED_ICLASS_FLDPI]   = {OP_MOV, -1, 1,
-                                            NONE};  // Potential FMOV
-  iclass_to_scarab_map[XED_ICLASS_FLDZ]    = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FMUL]    = {OP_FMUL, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FMULP]   = {OP_FMUL, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FNCLEX] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FNSTCW] = {OP_NOTPIPELINED_MEDIUM, -1, 1,
-                                             NONE};
-  iclass_to_scarab_map[XED_ICLASS_FNSTSW] = {OP_NOTPIPELINED_MEDIUM, -1, 1,
-                                             NONE};
-  iclass_to_scarab_map[XED_ICLASS_FNOP]   = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FPREM]  = {OP_FMUL, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FRNDINT]       = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FSETPM287_NOP] = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FSIN]    = {OP_NOTPIPELINED_VERY_SLOW, 8, 1,
-                                           NONE};
-  iclass_to_scarab_map[XED_ICLASS_FSINCOS] = {OP_NOTPIPELINED_VERY_SLOW, 8, 1,
-                                              NONE};
-  iclass_to_scarab_map[XED_ICLASS_FSQRT]   = {OP_FDIV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FST]     = {OP_MOV, -1, 1,
-                                          NONE};  // Potential FMOV
-  iclass_to_scarab_map[XED_ICLASS_FSTP]    = {OP_MOV, -1, 1,
-                                           NONE};  // Potential FMOV
-  iclass_to_scarab_map[XED_ICLASS_FSUB]    = {OP_FADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FSUBP]   = {OP_FADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FSUBR]   = {OP_FADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FSUBRP]  = {OP_FADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FUCOM]   = {OP_FCMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FUCOMI]  = {OP_FCMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FUCOMIP] = {OP_FCMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FUCOMP]  = {OP_FCMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FUCOMPP] = {OP_FCMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FWAIT]   = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FXAM]    = {OP_FCMP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FXCH]    = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_FYL2X]   = {OP_NOTPIPELINED_VERY_SLOW, 8, 1,
-                                            NONE};
-  iclass_to_scarab_map[XED_ICLASS_FYL2XP1] = {OP_NOTPIPELINED_VERY_SLOW, 8, 1,
-                                              NONE};
-  iclass_to_scarab_map[XED_ICLASS_IDIV]    = {OP_IDIV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_IMUL]    = {OP_IMUL, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_INC]     = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_INT]     = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_INT3]    = {OP_IADD, -1, 1, NONE};
-  // TODO: find out what opcodes these iclasses correspond to.
-  // iclass_to_scarab_map[XED_ICLASS_INCPPSD] = {OP_IADD, -1, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_INCPPSQ] = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_INC_LOCK] = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JB]       = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JBE]      = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JCXZ]     = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JECXZ]    = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JL]       = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JLE]      = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JMP]      = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JMP_FAR]  = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JNB]      = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JNBE]     = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JNL]      = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JNLE]     = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JNO]      = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JNP]      = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JNS]      = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JNZ]      = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JO]       = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JP]       = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JRCXZ]    = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JS]       = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_JZ]       = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_KNOTB]    = {OP_LOGIC, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_KNOTD]    = {OP_LOGIC, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_KNOTQ]    = {OP_LOGIC, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_KNOTW]    = {OP_LOGIC, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_KMOVB]    = {OP_MOV, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_KMOVD]    = {OP_MOV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_KMOVQ]    = {OP_MOV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_KMOVW]    = {OP_MOV, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_LDDQU]    = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_LDMXCSR]  = {OP_NOTPIPELINED_MEDIUM, -1, 1,
-                                              NONE};
-  iclass_to_scarab_map[XED_ICLASS_LEA]      = {OP_LDA, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_LEAVE]    = {OP_IADD, -1, 1, NONE};
-  // TODO: this should be a memory barrier if we want to support
-  // multi-threaded execution.
-  iclass_to_scarab_map[XED_ICLASS_LFENCE] = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_LODSB]  = {OP_MOV, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_LODSD]  = {OP_MOV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_LODSQ]  = {OP_MOV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_LODSW]  = {OP_MOV, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_LSL]    = {OP_LDA, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_LZCNT]  = {OP_PIPELINED_FAST, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MAXPD]  = {OP_FCMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MAXPS]  = {OP_FCMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MAXSD]  = {OP_FCMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MAXSS]  = {OP_FCMP, 4, 1, NONE};
-  // TODO: this should be a memory barrier if we want to support
-  // multi-threaded execution.
-  iclass_to_scarab_map[XED_ICLASS_MFENCE]    = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MINPD]     = {OP_FCMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MINPS]     = {OP_FCMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MINSD]     = {OP_FCMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MINSS]     = {OP_FCMP, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOV]       = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVAPD]    = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVAPS]    = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVBE]     = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVD]      = {OP_PIPELINED_FAST, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVDDUP]   = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVDQ2Q]   = {OP_PIPELINED_FAST, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVDQA]    = {OP_MOV, 8, 2, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVDQU]    = {OP_MOV, 8, 2, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVHLPS]   = {OP_MOV, 4, 2, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVHPD]    = {OP_MOV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVHPS]    = {OP_MOV, 4, 2, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVLHPS]   = {OP_MOV, 4, 2, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVLPD]    = {OP_MOV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVLPS]    = {OP_MOV, 4, 2, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVMSKPD]  = {OP_PIPELINED_FAST, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVMSKPS]  = {OP_PIPELINED_FAST, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVNTDQ]   = {OP_MOV, 8, 2, NT};
-  iclass_to_scarab_map[XED_ICLASS_MOVNTDQA]  = {OP_MOV, 8, 2, NT};
-  iclass_to_scarab_map[XED_ICLASS_MOVNTI]    = {OP_MOV, -1, 1, NT};
-  iclass_to_scarab_map[XED_ICLASS_MOVNTPD]   = {OP_MOV, 8, -1, NT};
-  iclass_to_scarab_map[XED_ICLASS_MOVNTPS]   = {OP_MOV, 4, -1, NT};
-  iclass_to_scarab_map[XED_ICLASS_MOVNTQ]    = {OP_MOV, 8, 1, NT};
-  iclass_to_scarab_map[XED_ICLASS_MOVNTSD]   = {OP_MOV, 8, 1, NT};
-  iclass_to_scarab_map[XED_ICLASS_MOVNTSS]   = {OP_MOV, 4, 1, NT};
-  iclass_to_scarab_map[XED_ICLASS_MOVQ]      = {OP_MOV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVQ2DQ]   = {OP_PIPELINED_FAST, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVSB]     = {OP_MOV, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVSD]     = {OP_MOV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVSD_XMM] = {OP_MOV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVSHDUP]  = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVSLDUP]  = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVSQ]     = {OP_MOV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVSS]     = {OP_MOV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVSW]     = {OP_MOV, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVSX]     = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVSXD]    = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVUPD]    = {OP_PIPELINED_FAST, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVUPS]    = {OP_PIPELINED_FAST, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MOVZX]     = {OP_MOV, -1, 1, NONE};
-  // Moves to debug and control registers, left unmapped
-  // iclass_to_scarab_map[XED_ICLASS_MOV_CR] = {OP_MOV, -1, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_MOV_DR] = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MPSADBW]   = {OP_NOTPIPELINED_MEDIUM, 1, 16,
-                                              NONE};
-  iclass_to_scarab_map[XED_ICLASS_MUL]       = {OP_IMUL, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MULPD]     = {OP_FMUL, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MULPS]     = {OP_FMUL, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MULSD]     = {OP_FMUL, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MULSS]     = {OP_FMUL, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_MULX]      = {OP_IMUL, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NEG]       = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NEG_LOCK]  = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NOP]       = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NOP2]      = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NOP3]      = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NOP4]      = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NOP5]      = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NOP6]      = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NOP7]      = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NOP8]      = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NOP9]      = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NOT]       = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_NOT_LOCK]  = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_OR]        = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ORPD]      = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ORPS]      = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_OR_LOCK]   = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PABSB]     = {OP_LOGIC, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PABSD]     = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PABSW]     = {OP_LOGIC, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PADDB]     = {OP_IADD, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PADDD]     = {OP_IADD, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PADDQ]     = {OP_IADD, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PADDSB]    = {OP_IADD, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PADDSW]    = {OP_IADD, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PADDUSB]   = {OP_IADD, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PADDUSW]   = {OP_IADD, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PADDW]     = {OP_IADD, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PALIGNR]   = {OP_SHIFT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PAND]      = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PANDN]     = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PAUSE]     = {OP_NOTPIPELINED_VERY_SLOW, 1, 1,
-                                            NONE};
-  iclass_to_scarab_map[XED_ICLASS_PAVGB]     = {OP_LOGIC, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PAVGW]     = {OP_LOGIC, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PBLENDVB]  = {OP_CMOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PBLENDW]   = {OP_CMOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PCMPEQB]   = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PCMPEQD]   = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PCMPEQQ]   = {OP_ICMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PCMPEQW]   = {OP_ICMP, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PCMPESTRI] = {OP_NOTPIPELINED_SLOW, 1, -1,
-                                                NONE};
-  iclass_to_scarab_map[XED_ICLASS_PCMPESTRM] = {OP_NOTPIPELINED_SLOW, 1, -1,
-                                                NONE};
-  iclass_to_scarab_map[XED_ICLASS_PCMPGTB]   = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PCMPGTD]   = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PCMPGTQ]   = {OP_ICMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PCMPGTW]   = {OP_ICMP, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PCMPISTRI] = {OP_NOTPIPELINED_SLOW, 1, -1,
-                                                NONE};
-  iclass_to_scarab_map[XED_ICLASS_PCMPISTRM] = {OP_NOTPIPELINED_SLOW, 1, -1,
-                                                NONE};
-  iclass_to_scarab_map[XED_ICLASS_PEXTRB]    = {OP_PIPELINED_FAST, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PEXTRD]    = {OP_PIPELINED_FAST, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PEXTRQ]    = {OP_PIPELINED_FAST, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PEXTRW]    = {OP_PIPELINED_FAST, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PEXTRW_SSE4] = {OP_PIPELINED_FAST, 2, 1,
-                                                  NONE};
-  iclass_to_scarab_map[XED_ICLASS_PINSRB]      = {OP_MOV, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PINSRD]      = {OP_MOV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PINSRQ]      = {OP_MOV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PINSRW]      = {OP_MOV, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVMSKB]  = {OP_PIPELINED_FAST, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMADDUBSW] = {OP_IMUL, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMADDWD]   = {OP_IMUL, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMAXSB]    = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMAXSD]    = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMAXSW]    = {OP_ICMP, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMAXUB]    = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMAXUD]    = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMAXUW]    = {OP_ICMP, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMINSB]    = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMINSD]    = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMINSW]    = {OP_ICMP, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMINUB]    = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMINUD]    = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMINUW]    = {OP_ICMP, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVMSKB]  = {OP_PIPELINED_FAST, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVSXBD]  = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVSXBQ]  = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVSXBW]  = {OP_CMOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVSXDQ]  = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVSXWD]  = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVSXWQ]  = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVZXBD]  = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVZXBQ]  = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVZXBW]  = {OP_CMOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVZXDQ]  = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVZXWD]  = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMOVZXWQ]  = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMULDQ]    = {OP_IMUL, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMULHRSW]  = {OP_IMUL, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMULHRW]   = {OP_IMUL, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMULHUW]   = {OP_IMUL, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMULHW]    = {OP_IMUL, 2, -1, NONE};
-  // according to Agner Fog, PMULLD is twice the latency of the other PMUL*
-  // instructions...
-  iclass_to_scarab_map[XED_ICLASS_PMULLD]  = {OP_PIPELINED_MEDIUM, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMULLW]  = {OP_IMUL, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PMULUDQ] = {OP_IMUL, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_POP]     = {OP_IADD, -1, 1, NONE};
-  // POPA and POPAD should create multiple micro-ops
-  // iclass_to_scarab_map[XED_ICLASS_POPA] = {OP_IADD, -1, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_POPAD] = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_POPCNT] = {OP_PIPELINED_MEDIUM, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_POPF]   = {OP_NOTPIPELINED_SLOW, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_POPFD]  = {OP_NOTPIPELINED_SLOW, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_POPFQ]  = {OP_NOTPIPELINED_SLOW, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_POR]    = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PREFETCHNTA] = {OP_MOV, -1, 1, NT};
-  iclass_to_scarab_map[XED_ICLASS_PREFETCHT0]  = {OP_MOV, -1, 1, T0};
-  iclass_to_scarab_map[XED_ICLASS_PREFETCHT1]  = {OP_MOV, -1, 1, T1};
-  iclass_to_scarab_map[XED_ICLASS_PREFETCHT2]  = {OP_MOV, -1, 1, T2};
-  iclass_to_scarab_map[XED_ICLASS_PREFETCHW]   = {OP_MOV, -1, 1, W};
-  iclass_to_scarab_map[XED_ICLASS_PREFETCHWT1] = {OP_MOV, -1, 1, WT1};
-  // iclass_to_scarab_map[XED_ICLASS_PREFETCH_EXCLUSIVE] = {OP_MOV, -1, 1,
-  // EXCLUSIVE};
-  // iclass_to_scarab_map[XED_ICLASS_PREFETCH_RESERVED] = {OP_MOV, -1, 1,
-  // RESERVED};
-  iclass_to_scarab_map[XED_ICLASS_PSADBW]    = {OP_PIPELINED_FAST, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSHUFB]    = {OP_MOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSHUFD]    = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSHUFHW]   = {OP_MOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSHUFLW]   = {OP_MOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSHUFW]    = {OP_MOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSLLD]     = {OP_SHIFT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSLLDQ]    = {OP_SHIFT, 16, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSLLQ]     = {OP_SHIFT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSLLW]     = {OP_SHIFT, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSRAD]     = {OP_SHIFT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSRAW]     = {OP_SHIFT, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSRLD]     = {OP_SHIFT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSRLDQ]    = {OP_SHIFT, 16, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSRLQ]     = {OP_SHIFT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSRLW]     = {OP_SHIFT, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSUBB]     = {OP_IADD, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSUBD]     = {OP_IADD, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSUBQ]     = {OP_IADD, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSUBSB]    = {OP_IADD, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSUBSW]    = {OP_IADD, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSUBUSB]   = {OP_IADD, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSUBUSW]   = {OP_IADD, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PSUBW]     = {OP_IADD, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PTEST]     = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PUNPCKHBW] = {OP_MOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PUNPCKHDQ] = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PUNPCKHQDQ] = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PUNPCKHWD]  = {OP_MOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PUNPCKLBW]  = {OP_MOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PUNPCKLDQ]  = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PUNPCKLQDQ] = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PUNPCKLWD]  = {OP_MOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PUSH]       = {OP_IADD, -1, 1, NONE};
-  // PUSHA and PUSHAD should create multiple micro-ops
-  // iclass_to_scarab_map[XED_ICLASS_PUSHA] = {OP_IADD, -1, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_PUSHAD] = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PUSHF]  = {OP_NOTPIPELINED_SLOW, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PUSHFD] = {OP_NOTPIPELINED_SLOW, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PUSHFQ] = {OP_NOTPIPELINED_SLOW, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_PXOR]   = {OP_LOGIC, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_RCPPS]  = {OP_FDIV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_RDTSC]  = {OP_NOTPIPELINED_SLOW, 4, 1, NONE};
-  // INS_Opcode() never returns REPEAT variants of the iclasses
-  // iclass_to_scarab_map[XED_ICLASS_REPE_CMPSB] = {OP_ICMP, 1, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_REPE_CMPSD] = {OP_ICMP, 4, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_REPE_CMPSQ] = {OP_ICMP, 8, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_REPE_CMPSW] = {OP_ICMP, 2, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_REPNE_CMPSB] = {OP_ICMP, 1, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_REPNE_CMPSD] = {OP_ICMP, 4, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_REPNE_CMPSQ] = {OP_ICMP, 8, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_REPNE_CMPSW] = {OP_ICMP, 2, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_REP_STOSB] = {OP_MOV, 1, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_REP_STOSD] = {OP_MOV, 4, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_REP_STOSQ] = {OP_MOV, 8, 1, NONE};
-  // iclass_to_scarab_map[XED_ICLASS_REP_STOSW] = {OP_MOV, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_RET_FAR]  = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_RET_NEAR] = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ROL]      = {OP_SHIFT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ROR]      = {OP_SHIFT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_RORX]     = {OP_SHIFT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ROUNDPD]  = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ROUNDPS]  = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ROUNDSD]  = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_ROUNDSS]  = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_RSQRTPS] = {OP_PIPELINED_MEDIUM, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_RSQRTSS] = {OP_PIPELINED_MEDIUM, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SAHF]    = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SAR]     = {OP_SHIFT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SARX]    = {OP_SHIFT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SBB]     = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SBB_LOCK] = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SCASB]    = {OP_ICMP, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SCASD]    = {OP_ICMP, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SCASQ]    = {OP_ICMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SCASW]    = {OP_ICMP, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETB]     = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETBE]    = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETL]     = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETLE]    = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETNB]    = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETNBE]   = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETNL]    = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETNLE]   = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETNO]    = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETNP]    = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETNS]    = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETNZ]    = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETO]     = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETP]     = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETS]     = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SETZ]     = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SHL]      = {OP_SHIFT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SHLD]     = {OP_SHIFT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SHLX]     = {OP_SHIFT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SHR]      = {OP_SHIFT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SHRD]     = {OP_SHIFT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SHRX]     = {OP_SHIFT, -1, 1, NONE};
-  // TODO: this should be a memory barrier if we want to support
-  // multi-threaded execution.
-  iclass_to_scarab_map[XED_ICLASS_SFENCE]  = {OP_NOP, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SHUFPD]  = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SHUFPS]  = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SQRTPD]  = {OP_FDIV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SQRTPS]  = {OP_FDIV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SQRTSD]  = {OP_FDIV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SQRTSS]  = {OP_FDIV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_STMXCSR] = {OP_PIPELINED_MEDIUM, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_STOSB]   = {OP_MOV, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_STOSD]   = {OP_MOV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_STOSQ]   = {OP_MOV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_STOSW]   = {OP_MOV, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SUB]     = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SUBPD]   = {OP_FADD, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SUBPS]   = {OP_FADD, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SUBSD]   = {OP_FADD, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SUBSS]   = {OP_FADD, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SUB_LOCK] = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SYSCALL]  = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_SYSENTER] = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_TEST]     = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_TZCNT]    = {OP_NOTPIPELINED_MEDIUM, -1, 1,
-                                            NONE};
-  iclass_to_scarab_map[XED_ICLASS_UCOMISD]  = {OP_FCMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_UCOMISS]  = {OP_FCMP, 4, -1, NONE};
-  // TODO: It works only for trace front-end now
-  iclass_to_scarab_map[XED_ICLASS_UD0]             = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_UD1]             = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_UD2]             = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_UNPCKHPD]        = {OP_MOV, -1, 8, NONE};
-  iclass_to_scarab_map[XED_ICLASS_UNPCKHPS]        = {OP_MOV, -1, 4, NONE};
-  iclass_to_scarab_map[XED_ICLASS_UNPCKLPD]        = {OP_MOV, -1, 8, NONE};
-  iclass_to_scarab_map[XED_ICLASS_UNPCKLPS]        = {OP_MOV, -1, 4, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VADDPD]          = {OP_FADD, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VADDPS]          = {OP_FADD, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VADDSD]          = {OP_FADD, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VADDSS]          = {OP_FADD, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VADDSUBPD]       = {OP_FADD, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VADDSUBPS]       = {OP_FADD, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VANDNPD]         = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VANDNPS]         = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VANDPD]          = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VANDPS]          = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBLENDMPD]       = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBLENDMPS]       = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBLENDPD]        = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBLENDPS]        = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBLENDVPD]       = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBLENDVPS]       = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTF128]  = {OP_MOV, 16, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTF32X2] = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTF32X4] = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTF32X8] = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTF64X2] = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTF64X4] = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTI128]  = {OP_MOV, 16, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTI32X2] = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTI32X4] = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTI32X8] = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTI64X2] = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTI64X4] = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTSD]    = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VBROADCASTSS]    = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCOMISD]         = {OP_ICMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCOMISS]         = {OP_ICMP, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCMPPD]          = {OP_FCMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCMPPS]          = {OP_FCMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCMPSD]          = {OP_FCMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCMPSS]          = {OP_FCMP, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTDQ2PD]       = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTDQ2PS]       = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTPD2DQ]       = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTPD2PS]       = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTPD2QQ]       = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTPD2UDQ]      = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTPD2UQQ]      = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTPH2PS]       = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTPS2DQ]       = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTPS2PD]       = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTPS2PH]       = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTPS2QQ]       = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTPS2UDQ]      = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTPS2UQQ]      = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTSD2SI]       = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTSD2SS]       = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTSD2USI]      = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTSI2SD]       = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTSI2SS]       = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTSS2SD]       = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTSS2SI]       = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTSS2USI]      = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTTPD2DQ]      = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTTPD2QQ]      = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTTPD2UDQ]     = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTTPD2UQQ]     = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTTPS2DQ]      = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTTPS2QQ]      = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTTPS2UDQ]     = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTTPS2UQQ]     = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTTSD2SI]      = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTTSD2USI]     = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTTSS2SI]      = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTTSS2USI]     = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTUDQ2PD]      = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTUDQ2PS]      = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTUQQ2PD]      = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTUQQ2PS]      = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTUSI2SD]      = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VCVTUSI2SS]      = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VDBPSADBW] = {OP_PIPELINED_FAST, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VDIVPD]    = {OP_FDIV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VDIVPS]    = {OP_FDIV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VDIVSD]    = {OP_FDIV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VDIVSS]    = {OP_FDIV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VEXTRACTF128]  = {OP_MOV, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VEXTRACTF32X4] = {OP_MOV, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VEXTRACTF32X8] = {OP_MOV, 32, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VEXTRACTF64X2] = {OP_MOV, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VEXTRACTF64X4] = {OP_MOV, 32, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VEXTRACTI128]  = {OP_MOV, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VEXTRACTI32X4] = {OP_MOV, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VEXTRACTI32X8] = {OP_MOV, 32, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VEXTRACTI64X2] = {OP_MOV, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VEXTRACTI64X4] = {OP_MOV, 32, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VEXTRACTPS]    = {OP_PIPELINED_FAST, 4, -1,
-                                                 NONE};
-  // FMA instructions
-  iclass_to_scarab_map[XED_ICLASS_VFMADD132PD]    = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADD132PS]    = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADD132SD]    = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADD132SS]    = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADD213PD]    = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADD213PS]    = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADD213SD]    = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADD213SS]    = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADD231PD]    = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADD231PS]    = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADD231SD]    = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADD231SS]    = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADDPD]       = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADDPS]       = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADDSD]       = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADDSS]       = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADDSUB132PD] = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADDSUB132PS] = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADDSUB213PD] = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADDSUB213PS] = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADDSUB231PD] = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADDSUB231PS] = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADDSUBPD]    = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMADDSUBPS]    = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUB132PD]    = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUB132PS]    = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUB132SD]    = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUB132SS]    = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUB213PD]    = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUB213PS]    = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUB213SD]    = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUB213SS]    = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUB231PD]    = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUB231PS]    = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUB231SD]    = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUB231SS]    = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUBADD132PD] = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUBADD132PS] = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUBADD213PD] = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUBADD213PS] = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUBADD231PD] = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUBADD231PS] = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUBADDPD]    = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUBADDPS]    = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUBPD]       = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUBPS]       = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUBSD]       = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFMSUBSS]       = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADD132PD]   = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADD132PS]   = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADD132SD]   = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADD132SS]   = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADD213PD]   = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADD213PS]   = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADD213SD]   = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADD213SS]   = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADD231PD]   = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADD231PS]   = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADD231SD]   = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADD231SS]   = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADDPD]      = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADDPS]      = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADDSD]      = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMADDSS]      = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUB132PD]   = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUB132PS]   = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUB132SD]   = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUB132SS]   = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUB213PD]   = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUB213PS]   = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUB213SD]   = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUB213SS]   = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUB231PD]   = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUB231PS]   = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUB231SD]   = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUB231SS]   = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUBPD]      = {OP_FMA, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUBPS]      = {OP_FMA, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUBSD]      = {OP_FMA, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VFNMSUBSS]      = {OP_FMA, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VGATHERDPD]     = {OP_GATHER, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VGATHERDPS]     = {OP_GATHER, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VGATHERPF0DPD]  = {OP_GATHER, 4, 16, T0};
-  iclass_to_scarab_map[XED_ICLASS_VGATHERPF0DPS]  = {OP_GATHER, 4, 16, T0};
-  iclass_to_scarab_map[XED_ICLASS_VGATHERPF0QPD]  = {OP_GATHER, 8, 8, T0};
-  iclass_to_scarab_map[XED_ICLASS_VGATHERPF0QPS]  = {OP_GATHER, 8, 8, T0};
-  iclass_to_scarab_map[XED_ICLASS_VGATHERPF1DPD]  = {OP_GATHER, 4, 16, T1};
-  iclass_to_scarab_map[XED_ICLASS_VGATHERPF1DPS]  = {OP_GATHER, 4, 16, T1};
-  iclass_to_scarab_map[XED_ICLASS_VGATHERPF1QPD]  = {OP_GATHER, 8, 8, T1};
-  iclass_to_scarab_map[XED_ICLASS_VGATHERPF1QPS]  = {OP_GATHER, 8, 8, T1};
-  iclass_to_scarab_map[XED_ICLASS_VGATHERQPD]     = {OP_GATHER, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VGATHERQPS]     = {OP_GATHER, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VGETEXPPD]      = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VGETEXPPS]      = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VGETEXPSD]      = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VGETEXPSS]      = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VGETMANTPD]     = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VGETMANTPS]     = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VGETMANTSD]     = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VGETMANTSS]     = {OP_FCVT, 4, 1, NONE};
-
-  iclass_to_scarab_map[XED_ICLASS_VINSERTF128]  = {OP_MOV, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VINSERTF32X4] = {OP_MOV, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VINSERTF32X8] = {OP_MOV, 32, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VINSERTF64X2] = {OP_MOV, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VINSERTF64X4] = {OP_MOV, 32, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VINSERTI128]  = {OP_MOV, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VINSERTI32X4] = {OP_MOV, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VINSERTI32X8] = {OP_MOV, 32, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VINSERTI64X2] = {OP_MOV, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VINSERTI64X4] = {OP_MOV, 32, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VINSERTPS]    = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VLDMXCSR]    = {OP_NOTPIPELINED_MEDIUM, -1, 1,
-                                               NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMASKMOVDQU] = {OP_PIPELINED_FAST, 1, -1,
-                                                  NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMASKMOVPD]  = {OP_PIPELINED_FAST, 8, -1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMASKMOVPS]  = {OP_PIPELINED_FAST, 4, -1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMAXPD]      = {OP_FCMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMAXPS]      = {OP_FCMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMAXSD]      = {OP_FCMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMAXSS]      = {OP_FCMP, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMINPD]      = {OP_FCMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMINPS]      = {OP_FCMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMINSD]      = {OP_FCMP, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMINSS]      = {OP_FCMP, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVAPD]     = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVAPS]     = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVD]       = {OP_MOV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVDDUP]    = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVDDUP]    = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVDQA]     = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVDQA32]   = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVDQA64]   = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVDQU]     = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVDQU16]   = {OP_MOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVDQU32]   = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVDQU64]   = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVDQU8]    = {OP_MOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVHLPS]    = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVHPD]     = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVHPS]     = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVLHPS]    = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVLPD]     = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVLPS]     = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVMSKPD] = {OP_PIPELINED_FAST, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVMSKPS] = {OP_PIPELINED_FAST, -1, 1, NONE};
-  // TODO: Scarab currently does not support stores with non-temporal hints.
-  // It will simply produces a store micro-op that does not bypass the cache.
-  // Should we model this as a simple OP_NOTPIPELINED_VERY_SLOW?
-  iclass_to_scarab_map[XED_ICLASS_VMOVNTDQ]  = {OP_MOV, -1, 1, NT};
-  iclass_to_scarab_map[XED_ICLASS_VMOVNTDQA] = {OP_MOV, -1, 1, NT};
-  iclass_to_scarab_map[XED_ICLASS_VMOVNTPD]  = {OP_MOV, 8, -1, NT};
-  iclass_to_scarab_map[XED_ICLASS_VMOVNTPS]  = {OP_MOV, 4, -1, NT};
-  iclass_to_scarab_map[XED_ICLASS_VMOVQ]     = {OP_MOV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVSD]    = {OP_MOV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVSHDUP] = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVSLDUP] = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVSS]    = {OP_MOV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVUPD]   = {OP_PIPELINED_FAST, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMOVUPS]   = {OP_PIPELINED_FAST, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMPSADBW]  = {OP_NOTPIPELINED_MEDIUM, 1, -1,
-                                               NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMULPD]    = {OP_FMUL, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMULPS]    = {OP_FMUL, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMULSD]    = {OP_FMUL, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VMULSS]    = {OP_FMUL, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VORPD]     = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VORPS]     = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPABSB]    = {OP_LOGIC, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPABSD]    = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPABSQ]    = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPABSW]    = {OP_LOGIC, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPACKSSDW] = {OP_MOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPACKSSWB] = {OP_MOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPACKUSDW] = {OP_MOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPACKUSWB] = {OP_MOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPADDB]    = {OP_IADD, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPADDD]    = {OP_IADD, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPADDQ]    = {OP_IADD, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPADDSB]   = {OP_IADD, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPADDSW]   = {OP_IADD, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPADDUSB]  = {OP_IADD, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPADDUSW]  = {OP_IADD, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPADDW]    = {OP_IADD, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPALIGNR]  = {OP_SHIFT, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPAND]     = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPANDD]    = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPANDN]    = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPANDND]   = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPANDNQ]   = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPANDQ]    = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPAVGB]    = {OP_LOGIC, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPAVGW]    = {OP_LOGIC, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBLENDD]  = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBLENDMB] = {OP_CMOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBLENDMD] = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBLENDMQ] = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBLENDMW] = {OP_CMOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBLENDVB] = {OP_CMOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBLENDW]  = {OP_CMOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBROADCASTB]    = {OP_MOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBROADCASTD]    = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBROADCASTMB2Q] = {OP_PIPELINED_MEDIUM, 8,
-                                                      -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBROADCASTMW2D] = {OP_PIPELINED_MEDIUM, 4,
-                                                      -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBROADCASTQ]    = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPBROADCASTW]    = {OP_MOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPB]          = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPD]          = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPEQB]        = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPEQD]        = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPEQQ]        = {OP_ICMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPEQW]        = {OP_ICMP, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPESTRI] = {OP_NOTPIPELINED_SLOW, 1, -1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPESTRM] = {OP_NOTPIPELINED_SLOW, 1, -1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPGTB]   = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPGTD]   = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPGTQ]   = {OP_ICMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPGTW]   = {OP_ICMP, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPISTRI] = {OP_NOTPIPELINED_SLOW, 1, -1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPCMPISTRM] = {OP_NOTPIPELINED_SLOW, 1, -1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPERM2F128] = {OP_MOV, 16, 1,
-                                                 NONE};  // TODO: Move or shift?
-  iclass_to_scarab_map[XED_ICLASS_VPERM2I128] = {OP_MOV, 16, 1,
-                                                 NONE};  // TODO: Move or shift?
-  iclass_to_scarab_map[XED_ICLASS_VPERMB]     = {OP_MOV, 1, -1,
-                                             NONE};  // TODO: Move or shift?
-  iclass_to_scarab_map[XED_ICLASS_VPERMD]     = {OP_MOV, 4, -1,
-                                             NONE};  // TODO: Move or shift?
-  iclass_to_scarab_map[XED_ICLASS_VPERMI2W]   = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPERMQ]     = {OP_MOV, 8, -1,
-                                             NONE};  // TODO: Move or shift?
-  iclass_to_scarab_map[XED_ICLASS_VPERMT2B]  = {OP_PIPELINED_FAST, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPERMT2D]  = {OP_PIPELINED_FAST, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPERMT2PD] = {OP_PIPELINED_FAST, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPERMT2PS] = {OP_PIPELINED_FAST, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPERMT2Q]  = {OP_PIPELINED_FAST, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPERMT2W]  = {OP_PIPELINED_FAST, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPERMW]    = {OP_MOV, 2, -1,
-                                             NONE};  // TODO: Move or shift?
-  iclass_to_scarab_map[XED_ICLASS_VPERMPD]   = {OP_PIPELINED_FAST, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPERMPS]   = {OP_PIPELINED_FAST, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPEXTRB]   = {OP_PIPELINED_FAST, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPEXTRD]   = {OP_PIPELINED_FAST, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPEXTRQ]   = {OP_PIPELINED_FAST, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPEXTRW]   = {OP_PIPELINED_FAST, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPGATHERDD] = {OP_GATHER, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPGATHERDQ] = {OP_GATHER, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPGATHERQD] = {OP_GATHER, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPGATHERQQ] = {OP_GATHER, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPINSRB]    = {OP_MOV, 1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPINSRD]    = {OP_MOV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPINSRQ]    = {OP_MOV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPINSRW]    = {OP_MOV, 2, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMADDUBSW] = {OP_IMUL, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMADDWD]   = {OP_IMUL, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMASKMOVD] = {OP_PIPELINED_MEDIUM, 4, -1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMASKMOVQ] = {OP_PIPELINED_MEDIUM, 8, -1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMAXSB]    = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMAXSD]    = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMAXSQ]    = {OP_ICMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMAXSW]    = {OP_ICMP, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMAXUB]    = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMAXUD]    = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMAXUQ]    = {OP_ICMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMAXUW]    = {OP_ICMP, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMINSB]    = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMINSD]    = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMINSQ]    = {OP_ICMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMINSW]    = {OP_ICMP, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMINUB]    = {OP_ICMP, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMINUD]    = {OP_ICMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMINUQ]    = {OP_ICMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMINUW]    = {OP_ICMP, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVB2M]  = {OP_PIPELINED_FAST, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVD2M]  = {OP_PIPELINED_FAST, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVDB]   = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVDW]   = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVM2B]  = {OP_PIPELINED_FAST, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVM2D]  = {OP_PIPELINED_FAST, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVM2Q]  = {OP_PIPELINED_FAST, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVM2W]  = {OP_PIPELINED_FAST, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVMSKB] = {OP_PIPELINED_FAST, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVQ2M]  = {OP_PIPELINED_FAST, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVQB]   = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVQD]   = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVQW]   = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVSDB]  = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVSDW]  = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVSQB]  = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVSQD]  = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVSQW]  = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVSWB]  = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVSXBD] = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVSXBQ] = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVSXBW] = {OP_CMOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVSXDQ] = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVSXWD] = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVSXWQ] = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVUSDB] = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVUSDW] = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVUSQB] = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVUSQD] = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVUSQW] = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVUSWB] = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVW2M]  = {OP_PIPELINED_FAST, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVWB]   = {OP_CMOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVZXBD] = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVZXBQ] = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVZXBW] = {OP_CMOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVZXDQ] = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVZXWD] = {OP_CMOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMOVZXWQ] = {OP_CMOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMULDQ]   = {OP_IMUL, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMULHRSW] = {OP_IMUL, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMULHUW]  = {OP_IMUL, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMULHW]   = {OP_IMUL, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMULLD] = {OP_PIPELINED_MEDIUM, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMULLQ] = {OP_PIPELINED_SLOW, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPMULLW] = {OP_IMUL, 2, -1, NONE};
-  // each destination lane of VPMULUDQ is 8 bytes, even though each source lane
-  // is only 4 bytes.
-  iclass_to_scarab_map[XED_ICLASS_VPMULUDQ] = {OP_IMUL, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPOR]     = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPORD]    = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPORQ]    = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSADBW]  = {OP_PIPELINED_FAST, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSCATTERDD] = {OP_SCATTER, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSCATTERDQ] = {OP_SCATTER, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSCATTERQD] = {OP_SCATTER, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSCATTERQQ] = {OP_SCATTER, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSHUFB]     = {OP_MOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSHUFD]     = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSHUFHW]    = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSHUFLW]    = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSLLD]      = {OP_SHIFT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSLLDQ]     = {OP_SHIFT, 16, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSLLQ]      = {OP_SHIFT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSLLVD]     = {OP_SHIFT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSLLVQ]     = {OP_SHIFT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSLLVW]     = {OP_SHIFT, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSLLW]      = {OP_SHIFT, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRAD]      = {OP_SHIFT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRAQ]      = {OP_SHIFT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRAVD]     = {OP_SHIFT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRAVQ]     = {OP_SHIFT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRAVW]     = {OP_SHIFT, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRAW]      = {OP_SHIFT, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRLD]      = {OP_SHIFT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRLDQ]     = {OP_SHIFT, 16, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRLQ]      = {OP_SHIFT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRLVD]     = {OP_SHIFT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRLVQ]     = {OP_SHIFT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRLVW]     = {OP_SHIFT, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSRLW]      = {OP_SHIFT, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSUBB]      = {OP_IADD, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSUBD]      = {OP_IADD, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSUBQ]      = {OP_IADD, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSUBSB]     = {OP_IADD, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSUBSW]     = {OP_IADD, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSUBUSB]    = {OP_IADD, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSUBUSW]    = {OP_IADD, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPSUBW]      = {OP_IADD, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPTERNLOGD]  = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPTERNLOGQ]  = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPTEST]      = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPUNPCKHBW]  = {OP_MOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPUNPCKHDQ]  = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPUNPCKHQDQ] = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPUNPCKHWD]  = {OP_MOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPUNPCKLBW]  = {OP_MOV, 1, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPUNPCKLDQ]  = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPUNPCKLQDQ] = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPUNPCKLWD]  = {OP_MOV, 2, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPXOR]       = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPXORD]      = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VPXORQ]      = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRCP14PD]    = {OP_NOTPIPELINED_MEDIUM, 8, -1,
-                                               NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRCP14PS]    = {OP_NOTPIPELINED_MEDIUM, 4, -1,
-                                               NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRCP14SD]    = {OP_NOTPIPELINED_MEDIUM, 8, 1,
-                                               NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRCP14SS]    = {OP_NOTPIPELINED_MEDIUM, 4, 1,
-                                               NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRCP28PD]    = {OP_NOTPIPELINED_MEDIUM, 8, -1,
-                                               NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRCP28PS]    = {OP_NOTPIPELINED_MEDIUM, 4, -1,
-                                               NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRCP28SD]    = {OP_NOTPIPELINED_MEDIUM, 8, 1,
-                                               NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRCP28SS]    = {OP_NOTPIPELINED_MEDIUM, 4, 1,
-                                               NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRCPPS]      = {OP_NOTPIPELINED_MEDIUM, 4, -1,
-                                             NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRCPSS]      = {OP_NOTPIPELINED_MEDIUM, 4, 1,
-                                             NONE};
-  iclass_to_scarab_map[XED_ICLASS_VREDUCEPD]   = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VREDUCEPS]   = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VREDUCESD]   = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VREDUCESS]   = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRNDSCALEPD] = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRNDSCALEPS] = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRNDSCALESD] = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRNDSCALESS] = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VROUNDPD]    = {OP_FCVT, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VROUNDPS]    = {OP_FCVT, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VROUNDSD]    = {OP_FCVT, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VROUNDSS]    = {OP_FCVT, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRSQRT14PD]  = {OP_PIPELINED_MEDIUM, 8, -1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRSQRT14PS]  = {OP_PIPELINED_MEDIUM, 4, -1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRSQRT14SD]  = {OP_PIPELINED_MEDIUM, 8, 1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRSQRT14SS]  = {OP_PIPELINED_MEDIUM, 4, 1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRSQRT28PD]  = {OP_PIPELINED_MEDIUM, 8, -1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRSQRT28PS]  = {OP_PIPELINED_MEDIUM, 4, -1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRSQRT28SD]  = {OP_PIPELINED_MEDIUM, 8, 1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRSQRT28SS]  = {OP_PIPELINED_MEDIUM, 4, 1,
-                                                 NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRSQRTPS]    = {OP_PIPELINED_MEDIUM, 4, -1,
-                                               NONE};
-  iclass_to_scarab_map[XED_ICLASS_VRSQRTSS] = {OP_PIPELINED_MEDIUM, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSCATTERDPD]    = {OP_SCATTER, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSCATTERDPS]    = {OP_SCATTER, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF0DPD] = {OP_SCATTER, 4, 16, T0};
-  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF0DPS] = {OP_SCATTER, 4, 16, T0};
-  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF0QPD] = {OP_SCATTER, 8, 8, T0};
-  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF0QPS] = {OP_SCATTER, 8, 8, T0};
-  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF1DPD] = {OP_SCATTER, 4, 16, T1};
-  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF1DPS] = {OP_SCATTER, 4, 16, T1};
-  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF1QPD] = {OP_SCATTER, 8, 8, T1};
-  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF1QPS] = {OP_SCATTER, 8, 8, T1};
-  iclass_to_scarab_map[XED_ICLASS_VSCATTERQPD]    = {OP_SCATTER, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSCATTERQPS]    = {OP_SCATTER, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSHUFPD]        = {OP_MOV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSHUFPS]        = {OP_MOV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSQRTPD]        = {OP_FDIV, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSQRTPS]        = {OP_FDIV, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSQRTSD]        = {OP_FDIV, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSQRTSS]        = {OP_FDIV, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSTMXCSR]   = {OP_NOTPIPELINED_MEDIUM, -1, 1,
-                                               NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSUBPD]     = {OP_FADD, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSUBPS]     = {OP_FADD, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSUBSD]     = {OP_FADD, 8, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VSUBSS]     = {OP_FADD, 4, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VUCOMISD]   = {OP_FCMP, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VUCOMISS]   = {OP_FCMP, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VUNPCKHPD]  = {OP_MOV, -1, 8, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VUNPCKHPS]  = {OP_MOV, -1, 4, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VUNPCKLPD]  = {OP_MOV, -1, 8, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VUNPCKLPS]  = {OP_MOV, -1, 4, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VXORPD]     = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VXORPS]     = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VZEROALL]   = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_VZEROUPPER] = {OP_LOGIC, 16, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_XADD]       = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_XADD_LOCK]  = {OP_IADD, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_XCHG]       = {OP_MOV, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_XGETBV] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_XOR]    = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_XORPD]  = {OP_LOGIC, 8, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_XORPS]  = {OP_LOGIC, 4, -1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_XOR_LOCK] = {OP_LOGIC, -1, 1, NONE};
-  iclass_to_scarab_map[XED_ICLASS_XRSTOR]   = {OP_NOTPIPELINED_VERY_SLOW, -1, 1,
-                                             NONE};
-  iclass_to_scarab_map[XED_ICLASS_XSAVE]    = {OP_NOTPIPELINED_VERY_SLOW, -1, 1,
-                                            NONE};
-  iclass_to_scarab_map[XED_ICLASS_XSAVEC]   = {OP_NOTPIPELINED_VERY_SLOW, -1, 1,
-                                             NONE};
-}

--- a/src/pin/pin_lib/decoder.h
+++ b/src/pin/pin_lib/decoder.h
@@ -29,17 +29,17 @@
 
 #undef UNUSED   // there is a name conflict between PIN and Scarab
 #undef WARNING  // there is a name conflict between PIN and Scarab
+#include <ostream>
 #include "../../ctype_pin_inst.h"
 #include "../../table_info.h"
 #include "x86_decoder.h"
-#include <ostream>
 
 using namespace std;
 
 void pin_decoder_init(bool translate_x87_regs, std::ostream* err_ostream);
 
-void pin_decoder_insert_analysis_functions(const INS& ins);
-void     insert_analysis_functions(ctype_pin_inst* info, const INS& ins);
+void            pin_decoder_insert_analysis_functions(const INS& ins);
+void            insert_analysis_functions(ctype_pin_inst* info, const INS& ins);
 ctype_pin_inst* pin_decoder_get_latest_inst();
 
 void pin_decoder_print_unknown_opcodes();

--- a/src/pin/pin_lib/gather_scatter_addresses.cc
+++ b/src/pin/pin_lib/gather_scatter_addresses.cc
@@ -21,17 +21,18 @@
 
 #include "gather_scatter_addresses.h"
 #include <iostream>
+#include <map>
+#include <cassert>
 
 // Global static instruction map just for scatter instructions
-typedef unordered_map<ADDRINT, gather_scatter_info> scatter_info_map;
 scatter_info_map                                    scatter_info_storage;
 
-void add_to_gather_scatter_info_storage(const ADDRINT iaddr,
-                                        const bool    is_gather,
-                                        const bool    is_scatter,
-                                        const INT32   category) {
-  ASSERTX(!(is_gather && is_scatter));
-  ASSERTX(is_gather || is_scatter);
+gather_scatter_info add_to_gather_scatter_info_storage(const ADDRINT iaddr,
+                                                       const bool    is_gather,
+                                                       const bool    is_scatter,
+                                           const xed_category_enum_t category) {
+  assert(!(is_gather && is_scatter));
+  assert(is_gather || is_scatter);
   gather_scatter_info::type type = is_gather ? gather_scatter_info::GATHER :
                                                gather_scatter_info::SCATTER;
   gather_scatter_info::mask_reg_type mask_reg_type;
@@ -46,49 +47,50 @@ void add_to_gather_scatter_info_storage(const ADDRINT iaddr,
       break;
 
     default:
-      ASSERT(false, std::string(
+      std::cout << std::string(
                       "unexpected category for gather/scatter instruction: ") +
-                      CATEGORY_StringShort(category));
+                  std::string(XED_CATEGORY_StringShort(category)) << std::endl;
+      assert(0);
       break;
   }
-  scatter_info_storage[iaddr] = gather_scatter_info(type, mask_reg_type);
+  return gather_scatter_info(type, mask_reg_type);
 }
 
 static void set_gather_scatter_data_width(
-  const ADDRINT iaddr, const REG pin_reg, const bool operandRead,
+  const ADDRINT iaddr, xed_reg_enum_t xed_reg, const bool operandRead,
   const bool operandWritten, const gather_scatter_info::type info_type,
   const gather_scatter_info::mask_reg_type mask_reg_type) {
-  ASSERTX(REG_is_xmm_ymm_zmm(pin_reg));
+  assert(XED_REG_is_xmm_ymm_zmm(xed_reg));
   switch(info_type) {
     case gather_scatter_info::GATHER:
       switch(mask_reg_type) {
         case gather_scatter_info::K:
-          ASSERTX(!operandRead && operandWritten);
+          assert(!operandRead && operandWritten);
           break;
         case gather_scatter_info::XYMM:
           // there's a bug in PIN as late as version 3.13 where INS_OperandRead
           // returns true for the destination reg (i.e., reg that we are
           // gathering into) for a AVX2 gather
-          ASSERTX(operandRead && operandWritten);
+          assert(operandRead && operandWritten);
           break;
         default:
-          ASSERTX(false);
+          assert(false);
           break;
       }
       break;
 
     case gather_scatter_info::SCATTER:
-      ASSERTX(operandRead && !operandWritten);
+      assert(operandRead && !operandWritten);
       break;
 
     default:
-      ASSERTX(false);
+      assert(false);
       break;
   }
-  scatter_info_storage[iaddr].set_data_reg_total_width(pin_reg);
+  scatter_info_storage[iaddr].set_data_reg_total_width(xed_reg);
 }
 
-void set_gather_scatter_reg_operand_info(const ADDRINT iaddr, const REG pin_reg,
+void set_gather_scatter_reg_operand_info(const ADDRINT iaddr, const xed_reg_enum_t pin_reg,
                                          const bool operandRead,
                                          const bool operandWritten) {
   const gather_scatter_info::type info_type =
@@ -96,16 +98,16 @@ void set_gather_scatter_reg_operand_info(const ADDRINT iaddr, const REG pin_reg,
   const gather_scatter_info::mask_reg_type mask_reg_type =
     scatter_info_storage[iaddr].get_mask_reg_type();
 
-  ASSERTX(gather_scatter_info::INVALID_TYPE != info_type);
-  ASSERTX(gather_scatter_info::INVALID_MASK_REG_TYPE != mask_reg_type);
+  assert(gather_scatter_info::INVALID_TYPE != info_type);
+  assert(gather_scatter_info::INVALID_MASK_REG_TYPE != mask_reg_type);
 
-  if(REG_is_k_mask(pin_reg)) {
-    ASSERTX(operandRead);
-    ASSERTX(operandWritten);
-    ASSERTX(gather_scatter_info::K == mask_reg_type);
+  if(XED_REG_is_k_mask(pin_reg)) {
+    assert(operandRead);
+    assert(operandWritten);
+    assert(gather_scatter_info::K == mask_reg_type);
     scatter_info_storage[iaddr].set_mask_reg(pin_reg);
   } else {
-    ASSERTX(REG_is_xmm_ymm_zmm(pin_reg));
+    assert(XED_REG_is_xmm_ymm_zmm(pin_reg));
     // for AVX2 gathers, both the destination
     // register (i.e., the register that we gather into) and the mask register
     // (i.e., the register that controls whether each lane gets predicated) are
@@ -128,23 +130,23 @@ void set_gather_scatter_reg_operand_info(const ADDRINT iaddr, const REG pin_reg,
 }
 
 void set_gather_scatter_memory_operand_info(
-  const ADDRINT iaddr, const REG pin_base_reg, const REG pin_index_reg,
-  const ADDRDELTA displacement, const UINT32 scale, const bool operandReadOnly,
+  const ADDRINT iaddr, const xed_reg_enum_t pin_base_reg, const xed_reg_enum_t pin_index_reg,
+  /*const uint64_t displacement,*/ const uint32_t scale, const bool operandReadOnly,
   const bool operandWritenOnly) {
   switch(scatter_info_storage[iaddr].get_type()) {
     case gather_scatter_info::GATHER:
-      ASSERTX(operandReadOnly);
+      assert(operandReadOnly);
       break;
     case gather_scatter_info::SCATTER:
-      ASSERTX(operandWritenOnly);
+      assert(operandWritenOnly);
       break;
     default:
-      ASSERTX(false);
+      assert(false);
       break;
   }
   scatter_info_storage[iaddr].set_base_reg(pin_base_reg);
   scatter_info_storage[iaddr].set_index_reg(pin_index_reg);
-  scatter_info_storage[iaddr].set_displacement(displacement);
+  //scatter_info_storage[iaddr].set_displacement(displacement);
   scatter_info_storage[iaddr].set_scale(scale);
 }
 
@@ -152,33 +154,33 @@ static void set_info_num_ld_or_st(const ADDRINT iaddr, ctype_pin_inst* info) {
   // set info->num_ld/st to the total number of mem ops (both mask on and off)
   // However, when we actually generate the compressed op, we're going to set
   // the num_ld/st of the compressed op to just the number of masked mem ops
-  ASSERTX(info->is_simd);
-  ASSERTX(info->is_gather_scatter);
+  assert(info->is_simd);
+  assert(info->is_gather_scatter);
 
-  UINT32 total_mask_on_and_off_mem_ops =
+  uint32_t total_mask_on_and_off_mem_ops =
     scatter_info_storage[iaddr].get_num_mem_ops();
   switch(scatter_info_storage[iaddr].get_type()) {
     case gather_scatter_info::GATHER:
       // should be set to 1 in decoder.cc:add_dependency_info, because PIN
       // treats gathers as having 1 memory operand
-      ASSERTX(1 == info->num_ld);
+      assert(1 == info->num_ld);
       info->num_ld = total_mask_on_and_off_mem_ops;
       break;
     case gather_scatter_info::SCATTER:
       // should be set to 1 in decoder.cc:add_dependency_info, because PIN
       // treats scatters as having 1 memory operand
-      ASSERTX(1 == info->num_st);
+      assert(1 == info->num_st);
       info->num_st = total_mask_on_and_off_mem_ops;
       break;
     default:
-      ASSERTX(false);
+      assert(false);
       break;
   }
 }
 
 void finalize_scatter_info(const ADDRINT iaddr, ctype_pin_inst* info) {
-  ASSERTX(info->is_simd);
-  ASSERTX(info->is_gather_scatter);
+  assert(info->is_simd);
+  assert(info->is_gather_scatter);
 
   switch(scatter_info_storage[iaddr].get_type()) {
     case gather_scatter_info::GATHER:
@@ -188,7 +190,7 @@ void finalize_scatter_info(const ADDRINT iaddr, ctype_pin_inst* info) {
       scatter_info_storage[iaddr].set_data_lane_width_bytes(info->st_size);
       break;
     default:
-      ASSERTX(false);
+      assert(false);
       break;
   }
   scatter_info_storage[iaddr].set_index_lane_width_bytes(
@@ -202,17 +204,17 @@ void finalize_scatter_info(const ADDRINT iaddr, ctype_pin_inst* info) {
   set_info_num_ld_or_st(iaddr, info);
 }
 
-void update_gather_scatter_num_ld_or_st(const ADDRINT                   iaddr,
+/*void update_gather_scatter_num_ld_or_st(const ADDRINT                   iaddr,
                                         const gather_scatter_info::type type,
                                         const uint      num_maskon_memops,
                                         ctype_pin_inst* info) {
-  ASSERTX(info->is_simd);
-  ASSERTX(info->is_gather_scatter);
-  ASSERTX(1 == scatter_info_storage.count(iaddr));
-  ASSERTX(type == scatter_info_storage[iaddr].get_type());
+  assert(info->is_simd);
+  assert(info->is_gather_scatter);
+  assert(1 == scatter_info_storage.count(iaddr));
+  assert(type == scatter_info_storage[iaddr].get_type());
   // number of actual mask on loads/stores should be less or equal to total of
   // mem ops (both mask on and off) in the gather/scatter instruction
-  UINT32 total_mask_on_and_off_mem_ops =
+  uint32_t total_mask_on_and_off_mem_ops =
     scatter_info_storage[iaddr].get_num_mem_ops();
   switch(type) {
     case gather_scatter_info::GATHER:
@@ -224,18 +226,18 @@ void update_gather_scatter_num_ld_or_st(const ADDRINT                   iaddr,
       info->num_st = num_maskon_memops;
       break;
     default:
-      ASSERTX(false);
+      assert(false);
       break;
   }
-}
+}*/
 
-static void verify_mem_access_infos(
+/*static void verify_mem_access_infos(
   const vector<PIN_MEM_ACCESS_INFO> computed_infos,
   const PIN_MULTI_MEM_ACCESS_INFO* infos_from_pin, bool base_reg_is_gr32) {
-  for(UINT32 lane_id = 0; lane_id < infos_from_pin->numberOfMemops; lane_id++) {
+  for(uint32_t lane_id = 0; lane_id < infos_from_pin->numberOfMemops; lane_id++) {
     ADDRINT        addr_from_pin = infos_from_pin->memop[lane_id].memoryAddress;
     PIN_MEMOP_ENUM type_from_pin = infos_from_pin->memop[lane_id].memopType;
-    UINT32         size_from_pin = infos_from_pin->memop[lane_id].bytesAccessed;
+    uint32_t         size_from_pin = infos_from_pin->memop[lane_id].bytesAccessed;
     bool           mask_on_from_pin = infos_from_pin->memop[lane_id].maskOn;
 
     // as late as PIN 3.13, there is a bug where PIN will not correctly compute
@@ -248,94 +250,32 @@ static void verify_mem_access_infos(
     } else {
       addr_mask = -1;
     }
-    ASSERTX((computed_infos[lane_id].memoryAddress & addr_mask) ==
+    assert((computed_infos[lane_id].memoryAddress & addr_mask) ==
             (addr_from_pin & addr_mask));
-    ASSERTX(computed_infos[lane_id].memopType == type_from_pin);
-    ASSERTX(computed_infos[lane_id].bytesAccessed == size_from_pin);
-    ASSERTX(computed_infos[lane_id].maskOn == mask_on_from_pin);
+    assert(computed_infos[lane_id].memopType == type_from_pin);
+    assert(computed_infos[lane_id].bytesAccessed == size_from_pin);
+    assert(computed_infos[lane_id].maskOn == mask_on_from_pin);
   }
-}
+  }*/
 
-vector<PIN_MEM_ACCESS_INFO>
-  get_gather_scatter_mem_access_infos_from_gather_scatter_info(
-    const CONTEXT* ctxt, const PIN_MULTI_MEM_ACCESS_INFO* infos_from_pin) {
-  ADDRINT iaddr;
-  PIN_GetContextRegval(ctxt, REG_INST_PTR, (UINT8*)&iaddr);
-  ASSERTX(1 == scatter_info_storage.count(iaddr));
-  vector<PIN_MEM_ACCESS_INFO> computed_infos =
-    scatter_info_storage[iaddr].compute_mem_access_infos(ctxt);
-  verify_mem_access_infos(computed_infos, infos_from_pin,
-                          scatter_info_storage[iaddr].base_reg_is_gr32());
-
-  return computed_infos;
-}
-
-bool gather_scatter_info::is_non_zero_and_powerof2(const UINT32 v) const {
+bool gather_scatter_info::is_non_zero_and_powerof2(const uint32_t v) const {
   return v && ((v & (v - 1)) == 0);
 }
 
-UINT32 gather_scatter_info::pin_xyzmm_reg_width_in_bytes(
-  const REG pin_xyzmm_reg) const {
-  ASSERTX(REG_is_xmm_ymm_zmm(pin_xyzmm_reg));
-  switch(REG_Width(pin_xyzmm_reg)) {
-    case REGWIDTH_128:
+uint32_t gather_scatter_info::pin_xyzmm_reg_width_in_bytes(
+  const xed_reg_enum_t pin_xyzmm_reg) const {
+  assert(XED_REG_is_xmm_ymm_zmm(pin_xyzmm_reg));
+  switch(XED_REG_Width(pin_xyzmm_reg)) {
+    case XED_REGWIDTH_128:
       return 16;
-    case REGWIDTH_256:
+    case XED_REGWIDTH_256:
       return 32;
-    case REGWIDTH_512:
+    case XED_REGWIDTH_512:
       return 64;
     default:
-      ASSERTX(false);
+      assert(false);
       return 0;
   }
-}
-
-PIN_MEMOP_ENUM gather_scatter_info::type_to_PIN_MEMOP_ENUM() const {
-  switch(_type) {
-    case GATHER:
-      return PIN_MEMOP_LOAD;
-    case SCATTER:
-      return PIN_MEMOP_STORE;
-    default:
-      ASSERTX(false);
-      return PIN_MEMOP_LOAD;
-  }
-}
-
-ADDRDELTA gather_scatter_info::compute_base_reg_addr_contribution(
-  const CONTEXT* ctxt) const {
-  ADDRDELTA base_addr_contribution = 0;
-  if(REG_valid(_base_reg)) {
-    PIN_REGISTER buf;
-    PIN_GetContextRegval(ctxt, _base_reg, (UINT8*)&buf);
-    // need to do this to make sure a 32-bit base register holding a negative
-    // value is properly sign-extended into a 64-bit ADDRDELTA value
-    if(REG_is_gr32(_base_reg)) {
-      base_addr_contribution = buf.s_dword[0];
-    } else if(REG_is_gr64(_base_reg)) {
-      base_addr_contribution = buf.s_qword[0];
-    } else {
-      ASSERTX(false);
-    }
-  }
-  return base_addr_contribution;
-}
-
-ADDRDELTA gather_scatter_info::compute_base_index_addr_contribution(
-  const PIN_REGISTER& vector_index_reg_val, const UINT32 lane_id) const {
-  ADDRDELTA index_val;
-  switch(_index_lane_width_bytes) {
-    case 4:
-      index_val = vector_index_reg_val.s_dword[lane_id];
-      break;
-    case 8:
-      index_val = vector_index_reg_val.s_qword[lane_id];
-      break;
-    default:
-      ASSERTX(false);
-      break;
-  }
-  return index_val;
 }
 
 gather_scatter_info::type gather_scatter_info::get_type() const {
@@ -347,6 +287,33 @@ gather_scatter_info::mask_reg_type gather_scatter_info::get_mask_reg_type()
   return _mask_reg_type;
 }
 
+xed_reg_enum_t gather_scatter_info::get_mask_reg() const {
+  return _mask_reg;
+}
+xed_reg_enum_t gather_scatter_info::get_base_reg() const {
+  return _base_reg;
+}
+
+xed_reg_enum_t gather_scatter_info::get_index_reg() const {
+  return _index_reg;
+}
+
+uint64_t gather_scatter_info::get_displacement() const {
+  return _displacement;
+}
+
+uint32_t gather_scatter_info::get_scale() const {
+  return _scale;
+}
+
+uint32_t gather_scatter_info::get_index_lane_width_bytes() const {
+  return _index_lane_width_bytes;
+}
+
+uint32_t gather_scatter_info::get_data_lane_width_bytes() const {
+  return _data_lane_width_bytes;
+}
+
 bool gather_scatter_info::data_dest_reg_set() const {
   return 0 != _data_vector_reg_total_width_bytes;
 }
@@ -356,9 +323,9 @@ gather_scatter_info::gather_scatter_info() {
   _mask_reg_type = gather_scatter_info::INVALID_MASK_REG_TYPE;
   _data_vector_reg_total_width_bytes = 0;
   _data_lane_width_bytes             = 0;
-  _mask_reg                          = REG_INVALID();
-  _base_reg                          = REG_INVALID();
-  _index_reg                         = REG_INVALID();
+  _mask_reg                          = XED_REG_INVALID();
+  _base_reg                          = XED_REG_INVALID();
+  _index_reg                         = XED_REG_INVALID();
   _displacement                      = 0;
   _scale                             = 0;
   _index_lane_width_bytes            = 0;
@@ -375,7 +342,7 @@ gather_scatter_info::gather_scatter_info(
 
 gather_scatter_info::~gather_scatter_info() {}
 
-ostream& operator<<(ostream& os, const gather_scatter_info& sinfo) {
+std::ostream& operator<<(std::ostream& os, const gather_scatter_info& sinfo) {
   os << "_type: " << sinfo.type_to_string[sinfo._type] << std::endl;
   os << "_data_vector_reg_total_width_bytes: " << std::dec
      << sinfo._data_vector_reg_total_width_bytes << std::endl;
@@ -383,9 +350,9 @@ ostream& operator<<(ostream& os, const gather_scatter_info& sinfo) {
      << std::endl;
   os << "_mask_reg_type: " << sinfo.type_to_string[sinfo._mask_reg_type]
      << std::endl;
-  os << "_k_mask_reg: " << REG_StringShort(sinfo._mask_reg) << std::endl;
-  os << "_base_reg: " << REG_StringShort(sinfo._base_reg) << std::endl;
-  os << "_index_reg: " << REG_StringShort(sinfo._index_reg) << std::endl;
+  os << "_k_mask_reg: " << XED_REG_StringShort(sinfo._mask_reg) << std::endl;
+  os << "_base_reg: " << XED_REG_StringShort(sinfo._base_reg) << std::endl;
+  os << "_index_reg: " << XED_REG_StringShort(sinfo._index_reg) << std::endl;
   os << "_displacement: 0x" << std::hex << sinfo._displacement << std::endl;
   os << "_scale: " << std::dec << sinfo._scale << std::endl;
   os << "_index_lane_width_bytes " << std::dec << sinfo._index_lane_width_bytes
@@ -394,154 +361,123 @@ ostream& operator<<(ostream& os, const gather_scatter_info& sinfo) {
   return os;
 }
 
-void gather_scatter_info::set_data_reg_total_width(const REG pin_reg) {
+void gather_scatter_info::set_data_reg_total_width(xed_reg_enum_t xed_reg) {
   // make sure data vector total width not set yet
-  ASSERTX(!data_dest_reg_set());
-  ASSERTX(REG_is_xmm_ymm_zmm(pin_reg));
-  _data_vector_reg_total_width_bytes = REG_Size(pin_reg);
-  ASSERTX(data_dest_reg_set());
+  assert(!data_dest_reg_set());
+  assert(XED_REG_is_xmm_ymm_zmm(xed_reg));
+  _data_vector_reg_total_width_bytes = XED_REG_Size(xed_reg);
+  assert(data_dest_reg_set());
 }
 
 void gather_scatter_info::set_data_lane_width_bytes(
-  const UINT32 st_lane_width) {
-  ASSERTX(0 == _data_lane_width_bytes);
+  const uint32_t st_lane_width) {
+  assert(0 == _data_lane_width_bytes);
   _data_lane_width_bytes = st_lane_width;
-  ASSERTX(0 != _data_lane_width_bytes);
+  assert(0 != _data_lane_width_bytes);
 }
 
 void gather_scatter_info::verify_mask_reg() const {
   switch(_mask_reg_type) {
     case gather_scatter_info::K:
-      ASSERTX(REG_is_k_mask(_mask_reg));
+      assert(XED_REG_is_k_mask(_mask_reg));
       break;
     case gather_scatter_info::XYMM:
-      ASSERTX(data_dest_reg_set());
-      ASSERTX(REG_is_xmm(_mask_reg) || REG_is_ymm(_mask_reg));
+      assert(data_dest_reg_set());
+      assert(XED_REG_is_xmm(_mask_reg) || XED_REG_is_ymm(_mask_reg));
       // for all AVX2 gather instructions, the width of the mask xmm/ymm
       // register and the destination register should be the same
-      ASSERTX(REG_Size(_mask_reg) == _data_vector_reg_total_width_bytes);
+      assert(XED_REG_Size(_mask_reg) == _data_vector_reg_total_width_bytes);
       break;
     default:
-      ASSERT(false, "unexpected mask reg type");
+      std::cout << std::string("unexpected mask reg type") << std::endl;
+      assert(0);
       break;
   }
 }
 
-void gather_scatter_info::set_mask_reg(const REG pin_reg) {
-  ASSERTX(!REG_valid(_mask_reg));  // make sure kmask not set yet
+void gather_scatter_info::set_mask_reg(const xed_reg_enum_t pin_reg) {
+  assert(!XED_REG_valid(_mask_reg));  // make sure kmask not set yet
   _mask_reg = pin_reg;
   verify_mask_reg();
 }
 
-void gather_scatter_info::set_base_reg(const REG pin_reg) {
+void gather_scatter_info::set_base_reg(const xed_reg_enum_t pin_reg) {
   // make sure base reg not set yet
-  ASSERTX(!REG_valid(_base_reg));
-  if(REG_valid(pin_reg)) {
+  assert(!XED_REG_valid(_base_reg));
+  if(XED_REG_valid(pin_reg)) {
     _base_reg = pin_reg;
-    ASSERTX(REG_is_gr64(pin_reg) || REG_is_gr32(pin_reg));
+    assert(XED_REG_is_gr64(pin_reg) || XED_REG_is_gr32(pin_reg));
   }
 }
 
-void gather_scatter_info::set_index_reg(const REG pin_reg) {
+void gather_scatter_info::set_index_reg(const xed_reg_enum_t pin_reg) {
   // make sure index reg not set yet
-  ASSERTX(!REG_valid(_index_reg));
-  if(REG_valid(pin_reg)) {
+  assert(!XED_REG_valid(_index_reg));
+  if(XED_REG_valid(pin_reg)) {
     _index_reg = pin_reg;
-    ASSERTX(REG_is_xmm_ymm_zmm(_index_reg));
+    assert(XED_REG_is_xmm_ymm_zmm(_index_reg));
   }
 }
 
-void gather_scatter_info::set_displacement(const ADDRDELTA displacement) {
-  ASSERTX(0 == _displacement);
+void gather_scatter_info::set_displacement(const uint64_t displacement) {
+  assert(0 == _displacement);
   _displacement = displacement;
   // displacement could still be 0, because not every scatter has a displacement
 }
 
-void gather_scatter_info::set_scale(const UINT32 scale) {
-  ASSERTX(0 == _scale);
+void gather_scatter_info::set_scale(const uint32_t scale) {
+  assert(0 == _scale);
   _scale = scale;
-  ASSERTX(is_non_zero_and_powerof2(_scale));
+  assert(is_non_zero_and_powerof2(_scale));
 }
 
 void gather_scatter_info::set_index_lane_width_bytes(
-  const UINT32 idx_lane_width) {
-  ASSERTX(0 == _index_lane_width_bytes);
+  const uint32_t idx_lane_width) {
+  assert(0 == _index_lane_width_bytes);
   _index_lane_width_bytes = idx_lane_width;
   // only expecting doubleword or quadword indices
-  ASSERTX((4 == _index_lane_width_bytes) || (8 == _index_lane_width_bytes));
+  assert((4 == _index_lane_width_bytes) || (8 == _index_lane_width_bytes));
 }
 
 void gather_scatter_info::compute_num_mem_ops() {
-  ASSERTX(0 == _num_mem_ops);
+  assert(0 == _num_mem_ops);
 
-  ASSERTX(is_non_zero_and_powerof2(_data_vector_reg_total_width_bytes));
-  ASSERTX(is_non_zero_and_powerof2(_data_lane_width_bytes));
-  UINT32 num_data_lanes = _data_vector_reg_total_width_bytes /
+  assert(is_non_zero_and_powerof2(_data_vector_reg_total_width_bytes));
+  assert(is_non_zero_and_powerof2(_data_lane_width_bytes));
+  uint32_t num_data_lanes = _data_vector_reg_total_width_bytes /
                           _data_lane_width_bytes;
-  ASSERTX(is_non_zero_and_powerof2(num_data_lanes));
+  assert(is_non_zero_and_powerof2(num_data_lanes));
 
-  UINT32 index_xyzmm_reg_width_bytes = pin_xyzmm_reg_width_in_bytes(_index_reg);
-  ASSERTX(is_non_zero_and_powerof2(index_xyzmm_reg_width_bytes));
-  ASSERTX(is_non_zero_and_powerof2(_index_lane_width_bytes));
-  UINT32 num_index_lanes = index_xyzmm_reg_width_bytes /
+  uint32_t index_xyzmm_reg_width_bytes = pin_xyzmm_reg_width_in_bytes(_index_reg);
+  assert(is_non_zero_and_powerof2(index_xyzmm_reg_width_bytes));
+  assert(is_non_zero_and_powerof2(_index_lane_width_bytes));
+  uint32_t num_index_lanes = index_xyzmm_reg_width_bytes /
                            _index_lane_width_bytes;
-  ASSERTX(is_non_zero_and_powerof2(num_index_lanes));
+  assert(is_non_zero_and_powerof2(num_index_lanes));
 
   _num_mem_ops = std::min(num_data_lanes, num_index_lanes);
-  ASSERTX(is_non_zero_and_powerof2(_num_mem_ops));
+  assert(is_non_zero_and_powerof2(_num_mem_ops));
 }
 
-UINT32 gather_scatter_info::get_num_mem_ops() const {
-  ASSERTX(is_non_zero_and_powerof2(_num_mem_ops));
+uint32_t gather_scatter_info::get_num_mem_ops() const {
+  assert(is_non_zero_and_powerof2(_num_mem_ops));
   return _num_mem_ops;
 }
 
 void gather_scatter_info::verify_fields_for_mem_access_info_generation() const {
   verify_mask_reg();
-  if(REG_valid(_base_reg)) {
-    ASSERTX(REG_is_gr64(_base_reg) || REG_is_gr32(_base_reg));
+  if(XED_REG_valid(_base_reg)) {
+    assert(XED_REG_is_gr64(_base_reg) || XED_REG_is_gr32(_base_reg));
   }
-  ASSERTX(REG_is_xmm_ymm_zmm(_index_reg));
-  ASSERTX(is_non_zero_and_powerof2(_scale));
-  ASSERTX((4 == _index_lane_width_bytes) || (8 == _index_lane_width_bytes));
-  ASSERTX((4 == _data_lane_width_bytes) || (8 == _data_lane_width_bytes));
-  ASSERTX(is_non_zero_and_powerof2(_num_mem_ops));
+  assert(XED_REG_is_xmm_ymm_zmm(_index_reg));
+  assert(is_non_zero_and_powerof2(_scale));
+  assert((4 == _index_lane_width_bytes) || (8 == _index_lane_width_bytes));
+  assert((4 == _data_lane_width_bytes) || (8 == _data_lane_width_bytes));
+  assert(is_non_zero_and_powerof2(_num_mem_ops));
 }
 
-bool gather_scatter_info::extract_mask_on(const PIN_REGISTER& mask_reg_val_buf,
-                                          const UINT32        lane_id) const {
-  bool   mask_on  = false;
-  UINT64 msb_mask = ((UINT64)1) << (_data_lane_width_bytes * 8 - 1);
-
-  switch(_mask_reg_type) {
-    case gather_scatter_info::K:
-      mask_on = (mask_reg_val_buf.word[0] & (1 << lane_id));
-      break;
-    case gather_scatter_info::XYMM:
-      // Conditionality is specified by the most significant bit of each data
-      // element of the mask register. The width of data element in the
-      // destination register and mask register are identical.
-      switch(_data_lane_width_bytes) {
-        case 4:
-          mask_on = (mask_reg_val_buf.dword[lane_id] & msb_mask);
-          break;
-
-        case 8:
-          mask_on = (mask_reg_val_buf.qword[lane_id] & msb_mask);
-          break;
-
-        default:
-          ASSERT(false, "expecting data lane width to be 4 or 8 bytes");
-          break;
-      }
-      break;
-    default:
-      ASSERTX(false);
-      break;
-  }
-  return mask_on;
-}
-
+/*
+//TODO: extract displacement information
 vector<PIN_MEM_ACCESS_INFO> gather_scatter_info::compute_mem_access_infos(
   const CONTEXT* ctxt) const {
   verify_fields_for_mem_access_info_generation();
@@ -551,11 +487,13 @@ vector<PIN_MEM_ACCESS_INFO> gather_scatter_info::compute_mem_access_infos(
   PIN_MEMOP_ENUM memop_type      = type_to_PIN_MEMOP_ENUM();
 
   PIN_REGISTER vector_index_reg_val_buf;
-  PIN_GetContextRegval(ctxt, _index_reg, (UINT8*)&vector_index_reg_val_buf);
+  assert(reg_xed_to_pin_map.find(_index_reg) != reg_xed_to_pin_map.end());
+  PIN_GetContextRegval(ctxt, reg_xed_to_pin_map[_index_reg], (UINT8*)&vector_index_reg_val_buf);
   PIN_REGISTER mask_reg_val_buf;
-  PIN_GetContextRegval(ctxt, _mask_reg, (UINT8*)&mask_reg_val_buf);
-  for(UINT32 lane_id = 0; lane_id < _num_mem_ops; lane_id++) {
-    ADDRDELTA index_val = compute_base_index_addr_contribution(
+  assert(reg_xed_to_pin_map.find(_mask_reg) != reg_xed_to_pin_map.end());
+  PIN_GetContextRegval(ctxt, reg_xed_to_pin_map[_mask_reg], (UINT8*)&mask_reg_val_buf);
+  for(uint32_t lane_id = 0; lane_id < _num_mem_ops; lane_id++) {
+    uint64_t index_val = compute_base_index_addr_contribution(
       vector_index_reg_val_buf, lane_id);
     ADDRINT final_addr = base_addr_contribution + (index_val * _scale) +
                          _displacement;
@@ -570,10 +508,12 @@ vector<PIN_MEM_ACCESS_INFO> gather_scatter_info::compute_mem_access_infos(
 
   return mem_access_infos;
 }
+*/
 
 bool gather_scatter_info::base_reg_is_gr32() const {
-  if(REG_valid(_base_reg) && REG_is_gr32(_base_reg)) {
+  if(XED_REG_valid(_base_reg) && XED_REG_is_gr32(_base_reg)) {
     return true;
   }
   return false;
 }
+

--- a/src/pin/pin_lib/gather_scatter_addresses.cc
+++ b/src/pin/pin_lib/gather_scatter_addresses.cc
@@ -20,17 +20,16 @@
  */
 
 #include "gather_scatter_addresses.h"
+#include <cassert>
 #include <iostream>
 #include <map>
-#include <cassert>
 
 // Global static instruction map just for scatter instructions
-scatter_info_map                                    scatter_info_storage;
+scatter_info_map scatter_info_storage;
 
-gather_scatter_info add_to_gather_scatter_info_storage(const ADDRINT iaddr,
-                                                       const bool    is_gather,
-                                                       const bool    is_scatter,
-                                           const xed_category_enum_t category) {
+gather_scatter_info add_to_gather_scatter_info_storage(
+  const ADDRINT iaddr, const bool is_gather, const bool is_scatter,
+  const xed_category_enum_t category) {
   assert(!(is_gather && is_scatter));
   assert(is_gather || is_scatter);
   gather_scatter_info::type type = is_gather ? gather_scatter_info::GATHER :
@@ -48,8 +47,9 @@ gather_scatter_info add_to_gather_scatter_info_storage(const ADDRINT iaddr,
 
     default:
       std::cout << std::string(
-                      "unexpected category for gather/scatter instruction: ") +
-                  std::string(XED_CATEGORY_StringShort(category)) << std::endl;
+                     "unexpected category for gather/scatter instruction: ") +
+                     std::string(XED_CATEGORY_StringShort(category))
+                << std::endl;
       assert(0);
       break;
   }
@@ -90,9 +90,10 @@ static void set_gather_scatter_data_width(
   scatter_info_storage[iaddr].set_data_reg_total_width(xed_reg);
 }
 
-void set_gather_scatter_reg_operand_info(const ADDRINT iaddr, const xed_reg_enum_t pin_reg,
-                                         const bool operandRead,
-                                         const bool operandWritten) {
+void set_gather_scatter_reg_operand_info(const ADDRINT        iaddr,
+                                         const xed_reg_enum_t pin_reg,
+                                         const bool           operandRead,
+                                         const bool           operandWritten) {
   const gather_scatter_info::type info_type =
     scatter_info_storage[iaddr].get_type();
   const gather_scatter_info::mask_reg_type mask_reg_type =
@@ -130,9 +131,10 @@ void set_gather_scatter_reg_operand_info(const ADDRINT iaddr, const xed_reg_enum
 }
 
 void set_gather_scatter_memory_operand_info(
-  const ADDRINT iaddr, const xed_reg_enum_t pin_base_reg, const xed_reg_enum_t pin_index_reg,
-  /*const uint64_t displacement,*/ const uint32_t scale, const bool operandReadOnly,
-  const bool operandWritenOnly) {
+  const ADDRINT iaddr, const xed_reg_enum_t pin_base_reg,
+  const xed_reg_enum_t                            pin_index_reg,
+  /*const uint64_t displacement,*/ const uint32_t scale,
+  const bool operandReadOnly, const bool operandWritenOnly) {
   switch(scatter_info_storage[iaddr].get_type()) {
     case gather_scatter_info::GATHER:
       assert(operandReadOnly);
@@ -146,7 +148,7 @@ void set_gather_scatter_memory_operand_info(
   }
   scatter_info_storage[iaddr].set_base_reg(pin_base_reg);
   scatter_info_storage[iaddr].set_index_reg(pin_index_reg);
-  //scatter_info_storage[iaddr].set_displacement(displacement);
+  // scatter_info_storage[iaddr].set_displacement(displacement);
   scatter_info_storage[iaddr].set_scale(scale);
 }
 
@@ -234,11 +236,12 @@ void finalize_scatter_info(const ADDRINT iaddr, ctype_pin_inst* info) {
 /*static void verify_mem_access_infos(
   const vector<PIN_MEM_ACCESS_INFO> computed_infos,
   const PIN_MULTI_MEM_ACCESS_INFO* infos_from_pin, bool base_reg_is_gr32) {
-  for(uint32_t lane_id = 0; lane_id < infos_from_pin->numberOfMemops; lane_id++) {
-    ADDRINT        addr_from_pin = infos_from_pin->memop[lane_id].memoryAddress;
+  for(uint32_t lane_id = 0; lane_id < infos_from_pin->numberOfMemops; lane_id++)
+  { ADDRINT        addr_from_pin = infos_from_pin->memop[lane_id].memoryAddress;
     PIN_MEMOP_ENUM type_from_pin = infos_from_pin->memop[lane_id].memopType;
-    uint32_t         size_from_pin = infos_from_pin->memop[lane_id].bytesAccessed;
-    bool           mask_on_from_pin = infos_from_pin->memop[lane_id].maskOn;
+    uint32_t         size_from_pin =
+  infos_from_pin->memop[lane_id].bytesAccessed; bool           mask_on_from_pin
+  = infos_from_pin->memop[lane_id].maskOn;
 
     // as late as PIN 3.13, there is a bug where PIN will not correctly compute
     // the full 64 addresses of gathers/scatters if the base register is a
@@ -445,14 +448,15 @@ void gather_scatter_info::compute_num_mem_ops() {
   assert(is_non_zero_and_powerof2(_data_vector_reg_total_width_bytes));
   assert(is_non_zero_and_powerof2(_data_lane_width_bytes));
   uint32_t num_data_lanes = _data_vector_reg_total_width_bytes /
-                          _data_lane_width_bytes;
+                            _data_lane_width_bytes;
   assert(is_non_zero_and_powerof2(num_data_lanes));
 
-  uint32_t index_xyzmm_reg_width_bytes = pin_xyzmm_reg_width_in_bytes(_index_reg);
+  uint32_t index_xyzmm_reg_width_bytes = pin_xyzmm_reg_width_in_bytes(
+    _index_reg);
   assert(is_non_zero_and_powerof2(index_xyzmm_reg_width_bytes));
   assert(is_non_zero_and_powerof2(_index_lane_width_bytes));
   uint32_t num_index_lanes = index_xyzmm_reg_width_bytes /
-                           _index_lane_width_bytes;
+                             _index_lane_width_bytes;
   assert(is_non_zero_and_powerof2(num_index_lanes));
 
   _num_mem_ops = std::min(num_data_lanes, num_index_lanes);
@@ -488,12 +492,12 @@ vector<PIN_MEM_ACCESS_INFO> gather_scatter_info::compute_mem_access_infos(
 
   PIN_REGISTER vector_index_reg_val_buf;
   assert(reg_xed_to_pin_map.find(_index_reg) != reg_xed_to_pin_map.end());
-  PIN_GetContextRegval(ctxt, reg_xed_to_pin_map[_index_reg], (UINT8*)&vector_index_reg_val_buf);
-  PIN_REGISTER mask_reg_val_buf;
+  PIN_GetContextRegval(ctxt, reg_xed_to_pin_map[_index_reg],
+(UINT8*)&vector_index_reg_val_buf); PIN_REGISTER mask_reg_val_buf;
   assert(reg_xed_to_pin_map.find(_mask_reg) != reg_xed_to_pin_map.end());
-  PIN_GetContextRegval(ctxt, reg_xed_to_pin_map[_mask_reg], (UINT8*)&mask_reg_val_buf);
-  for(uint32_t lane_id = 0; lane_id < _num_mem_ops; lane_id++) {
-    uint64_t index_val = compute_base_index_addr_contribution(
+  PIN_GetContextRegval(ctxt, reg_xed_to_pin_map[_mask_reg],
+(UINT8*)&mask_reg_val_buf); for(uint32_t lane_id = 0; lane_id < _num_mem_ops;
+lane_id++) { uint64_t index_val = compute_base_index_addr_contribution(
       vector_index_reg_val_buf, lane_id);
     ADDRINT final_addr = base_addr_contribution + (index_val * _scale) +
                          _displacement;
@@ -516,4 +520,3 @@ bool gather_scatter_info::base_reg_is_gr32() const {
   }
   return false;
 }
-

--- a/src/pin/pin_lib/gather_scatter_addresses.h
+++ b/src/pin/pin_lib/gather_scatter_addresses.h
@@ -24,12 +24,15 @@
 
 #include <unordered_map>
 #include <vector>
+#include <string>
+#include <ostream>
 #undef UNUSED   // there is a name conflict between PIN and Scarab
 #undef WARNING  // there is a name conflict between PIN and Scarab
-#include "pin.H"
+//#include "pin.H"
 #undef UNUSED   // there is a name conflict between PIN and Scarab
 #undef WARNING  // there is a name conflict between PIN and Scarab
 #include "../../ctype_pin_inst.h"
+#include "pin_api_to_xed.h"
 
 class gather_scatter_info {
  public:
@@ -50,65 +53,63 @@ class gather_scatter_info {
   gather_scatter_info::mask_reg_type get_mask_reg_type() const;
   bool                               data_dest_reg_set() const;
 
-  void   set_data_reg_total_width(const REG pin_reg);
-  void   set_data_lane_width_bytes(const UINT32 st_lane_width);
-  void   set_mask_reg(const REG pin_reg);
-  void   set_base_reg(const REG pin_reg);
-  void   set_index_reg(const REG pin_reg);
-  void   set_displacement(const ADDRDELTA displacement);
-  void   set_scale(const UINT32 scale);
-  void   set_index_lane_width_bytes(const UINT32 idx_lane_width);
+  void   set_data_reg_total_width(const xed_reg_enum_t pin_reg);
+  void   set_data_lane_width_bytes(const uint32_t st_lane_width);
+  uint32_t get_data_lane_width_bytes() const;
+  void   set_mask_reg(const xed_reg_enum_t pin_reg);
+  void   set_base_reg(const xed_reg_enum_t pin_reg);
+  void   set_index_reg(const xed_reg_enum_t pin_reg);
+  xed_reg_enum_t get_mask_reg() const;
+  xed_reg_enum_t get_base_reg() const;
+  xed_reg_enum_t get_index_reg() const;
+  void   set_displacement(const uint64_t displacement);
+  uint64_t get_displacement() const;
+  void   set_scale(const uint32_t scale);
+  uint32_t get_scale() const;
+  void   set_index_lane_width_bytes(const uint32_t idx_lane_width);
+  uint32_t get_index_lane_width_bytes() const;
   void   compute_num_mem_ops();
-  UINT32 get_num_mem_ops() const;
+  uint32_t get_num_mem_ops() const;
   void   verify_fields_for_mem_access_info_generation() const;
-  vector<PIN_MEM_ACCESS_INFO> compute_mem_access_infos(
-    const CONTEXT* ctxt) const;
   bool base_reg_is_gr32() const;
 
-  friend ostream& operator<<(ostream& os, const gather_scatter_info& sinfo);
+  friend std::ostream& operator<<(std::ostream& os, const gather_scatter_info& sinfo);
 
  private:
   gather_scatter_info::type          _type;
   gather_scatter_info::mask_reg_type _mask_reg_type;
-  UINT32                             _data_vector_reg_total_width_bytes;
-  UINT32                             _data_lane_width_bytes;
-  REG                                _mask_reg;
-  REG                                _base_reg;
-  REG                                _index_reg;
-  ADDRDELTA                          _displacement;
-  UINT32                             _scale;
-  UINT32                             _index_lane_width_bytes;
-  UINT32                             _num_mem_ops;
+  uint32_t                             _data_vector_reg_total_width_bytes;
+  uint32_t                             _data_lane_width_bytes;
+  xed_reg_enum_t                                _mask_reg;
+  xed_reg_enum_t                                _base_reg;
+  xed_reg_enum_t                                _index_reg;
+  uint64_t                          _displacement;
+  uint32_t                             _scale;
+  uint32_t                             _index_lane_width_bytes;
+  uint32_t                             _num_mem_ops;
 
-  bool      is_non_zero_and_powerof2(const UINT32 v) const;
-  UINT32    pin_xyzmm_reg_width_in_bytes(const REG pin_xyzmm_reg) const;
-  ADDRDELTA compute_base_reg_addr_contribution(const CONTEXT* ctxt) const;
-  ADDRDELTA compute_base_index_addr_contribution(
-    const PIN_REGISTER& vector_index_reg_val, const UINT32 lane_id) const;
-  PIN_MEMOP_ENUM type_to_PIN_MEMOP_ENUM() const;
+  bool      is_non_zero_and_powerof2(const uint32_t v) const;
+  uint32_t    pin_xyzmm_reg_width_in_bytes(const xed_reg_enum_t pin_xyzmm_reg) const;
   void           verify_mask_reg() const;
-  bool           extract_mask_on(const PIN_REGISTER& mask_reg_val_buf,
-                                 const UINT32        lane_id) const;
 };
 
-void add_to_gather_scatter_info_storage(const ADDRINT iaddr,
-                                        const bool    is_gather,
-                                        const bool    is_scatter,
-                                        const INT32   category);
-void set_gather_scatter_reg_operand_info(const ADDRINT iaddr, const REG pin_reg,
+typedef std::unordered_map<ADDRINT, gather_scatter_info> scatter_info_map;
+gather_scatter_info add_to_gather_scatter_info_storage(const ADDRINT iaddr,
+                                                       const bool    is_gather,
+                                                       const bool    is_scatter,
+                                            const xed_category_enum_t category);
+void set_gather_scatter_reg_operand_info(const ADDRINT iaddr,
+                                         const xed_reg_enum_t pin_reg,
                                          const bool operandRead,
                                          const bool operandWritten);
 void set_gather_scatter_memory_operand_info(
-  const ADDRINT iaddr, const REG pin_base_reg, const REG pin_index_reg,
-  const ADDRDELTA displacement, const UINT32 scale, const bool operandReadOnly,
-  const bool operandWritenOnly);
+                                            const ADDRINT iaddr,
+                                            const xed_reg_enum_t pin_base_reg,
+                                            const xed_reg_enum_t pin_index_reg,
+                                            const uint32_t scale,
+                                            const bool operandReadOnly,
+                                            const bool operandWritenOnly);
 void finalize_scatter_info(const ADDRINT iaddr, ctype_pin_inst* info);
-vector<PIN_MEM_ACCESS_INFO>
-  get_gather_scatter_mem_access_infos_from_gather_scatter_info(
-    const CONTEXT* ctxt, const PIN_MULTI_MEM_ACCESS_INFO* infos_from_pin);
-void update_gather_scatter_num_ld_or_st(const ADDRINT                   iaddr,
-                                        const gather_scatter_info::type type,
-                                        const uint      num_maskon_memops,
-                                        ctype_pin_inst* info);
+void init_reg_xed_to_pin_map();
 
 #endif  // __SCATTER_H__

--- a/src/pin/pin_lib/gather_scatter_addresses.h
+++ b/src/pin/pin_lib/gather_scatter_addresses.h
@@ -22,10 +22,10 @@
 #ifndef __SCATTER_H__
 #define __SCATTER_H__
 
+#include <ostream>
+#include <string>
 #include <unordered_map>
 #include <vector>
-#include <string>
-#include <ostream>
 #undef UNUSED   // there is a name conflict between PIN and Scarab
 #undef WARNING  // there is a name conflict between PIN and Scarab
 //#include "pin.H"
@@ -53,60 +53,60 @@ class gather_scatter_info {
   gather_scatter_info::mask_reg_type get_mask_reg_type() const;
   bool                               data_dest_reg_set() const;
 
-  void   set_data_reg_total_width(const xed_reg_enum_t pin_reg);
-  void   set_data_lane_width_bytes(const uint32_t st_lane_width);
-  uint32_t get_data_lane_width_bytes() const;
-  void   set_mask_reg(const xed_reg_enum_t pin_reg);
-  void   set_base_reg(const xed_reg_enum_t pin_reg);
-  void   set_index_reg(const xed_reg_enum_t pin_reg);
+  void           set_data_reg_total_width(const xed_reg_enum_t pin_reg);
+  void           set_data_lane_width_bytes(const uint32_t st_lane_width);
+  uint32_t       get_data_lane_width_bytes() const;
+  void           set_mask_reg(const xed_reg_enum_t pin_reg);
+  void           set_base_reg(const xed_reg_enum_t pin_reg);
+  void           set_index_reg(const xed_reg_enum_t pin_reg);
   xed_reg_enum_t get_mask_reg() const;
   xed_reg_enum_t get_base_reg() const;
   xed_reg_enum_t get_index_reg() const;
-  void   set_displacement(const uint64_t displacement);
-  uint64_t get_displacement() const;
-  void   set_scale(const uint32_t scale);
-  uint32_t get_scale() const;
-  void   set_index_lane_width_bytes(const uint32_t idx_lane_width);
-  uint32_t get_index_lane_width_bytes() const;
-  void   compute_num_mem_ops();
-  uint32_t get_num_mem_ops() const;
-  void   verify_fields_for_mem_access_info_generation() const;
-  bool base_reg_is_gr32() const;
+  void           set_displacement(const uint64_t displacement);
+  uint64_t       get_displacement() const;
+  void           set_scale(const uint32_t scale);
+  uint32_t       get_scale() const;
+  void           set_index_lane_width_bytes(const uint32_t idx_lane_width);
+  uint32_t       get_index_lane_width_bytes() const;
+  void           compute_num_mem_ops();
+  uint32_t       get_num_mem_ops() const;
+  void           verify_fields_for_mem_access_info_generation() const;
+  bool           base_reg_is_gr32() const;
 
-  friend std::ostream& operator<<(std::ostream& os, const gather_scatter_info& sinfo);
+  friend std::ostream& operator<<(std::ostream&              os,
+                                  const gather_scatter_info& sinfo);
 
  private:
   gather_scatter_info::type          _type;
   gather_scatter_info::mask_reg_type _mask_reg_type;
-  uint32_t                             _data_vector_reg_total_width_bytes;
-  uint32_t                             _data_lane_width_bytes;
-  xed_reg_enum_t                                _mask_reg;
-  xed_reg_enum_t                                _base_reg;
-  xed_reg_enum_t                                _index_reg;
-  uint64_t                          _displacement;
-  uint32_t                             _scale;
-  uint32_t                             _index_lane_width_bytes;
-  uint32_t                             _num_mem_ops;
+  uint32_t                           _data_vector_reg_total_width_bytes;
+  uint32_t                           _data_lane_width_bytes;
+  xed_reg_enum_t                     _mask_reg;
+  xed_reg_enum_t                     _base_reg;
+  xed_reg_enum_t                     _index_reg;
+  uint64_t                           _displacement;
+  uint32_t                           _scale;
+  uint32_t                           _index_lane_width_bytes;
+  uint32_t                           _num_mem_ops;
 
-  bool      is_non_zero_and_powerof2(const uint32_t v) const;
-  uint32_t    pin_xyzmm_reg_width_in_bytes(const xed_reg_enum_t pin_xyzmm_reg) const;
-  void           verify_mask_reg() const;
+  bool     is_non_zero_and_powerof2(const uint32_t v) const;
+  uint32_t pin_xyzmm_reg_width_in_bytes(
+    const xed_reg_enum_t pin_xyzmm_reg) const;
+  void verify_mask_reg() const;
 };
 
 typedef std::unordered_map<ADDRINT, gather_scatter_info> scatter_info_map;
-gather_scatter_info add_to_gather_scatter_info_storage(const ADDRINT iaddr,
-                                                       const bool    is_gather,
-                                                       const bool    is_scatter,
-                                            const xed_category_enum_t category);
-void set_gather_scatter_reg_operand_info(const ADDRINT iaddr,
+gather_scatter_info add_to_gather_scatter_info_storage(
+  const ADDRINT iaddr, const bool is_gather, const bool is_scatter,
+  const xed_category_enum_t category);
+void set_gather_scatter_reg_operand_info(const ADDRINT        iaddr,
                                          const xed_reg_enum_t pin_reg,
-                                         const bool operandRead,
-                                         const bool operandWritten);
-void set_gather_scatter_memory_operand_info(
-                                            const ADDRINT iaddr,
+                                         const bool           operandRead,
+                                         const bool           operandWritten);
+void set_gather_scatter_memory_operand_info(const ADDRINT        iaddr,
                                             const xed_reg_enum_t pin_base_reg,
                                             const xed_reg_enum_t pin_index_reg,
-                                            const uint32_t scale,
+                                            const uint32_t       scale,
                                             const bool operandReadOnly,
                                             const bool operandWritenOnly);
 void finalize_scatter_info(const ADDRINT iaddr, ctype_pin_inst* info);

--- a/src/pin/pin_lib/pin_api_to_xed.h
+++ b/src/pin/pin_lib/pin_api_to_xed.h
@@ -38,93 +38,122 @@
 #define THIRD_PARTY_ZSIM_SRC_WRAPPED_PIN_H_
 
 extern "C" {
-  #include "xed-interface.h"
+#include "xed-interface.h"
 }
 
-enum class CustomOp : uint8_t {
-  NONE,
-  PREFETCH_CODE
-};
+enum class CustomOp : uint8_t { NONE, PREFETCH_CODE };
 
 struct InstInfo {
-  uint64_t pc;                    // instruction address
-  const xed_decoded_inst_t *ins;  // XED info
-  uint64_t pid;                   // process ID
-  uint64_t tid;                   // thread ID
-  uint64_t target;                // branch target
-  uint64_t mem_addr[2];           // memory addresses
-  bool mem_used[2];               // mem address usage flags
-  CustomOp custom_op;             // Special or non-x86 ISA instruction
-  bool taken;                     // branch taken
-  bool unknown_type;              // No available decode info (presents a nop)
-  bool valid;                     // True until the end of the sequence
+  uint64_t                  pc;           // instruction address
+  const xed_decoded_inst_t* ins;          // XED info
+  uint64_t                  pid;          // process ID
+  uint64_t                  tid;          // thread ID
+  uint64_t                  target;       // branch target
+  uint64_t                  mem_addr[2];  // memory addresses
+  bool                      mem_used[2];  // mem address usage flags
+  CustomOp                  custom_op;    // Special or non-x86 ISA instruction
+  bool                      taken;        // branch taken
+  bool unknown_type;  // No available decode info (presents a nop)
+  bool valid;         // True until the end of the sequence
 };
 
-#define XED_OP_NAME(ins, op) xed_operand_name(xed_inst_operand(xed_decoded_inst_inst(ins), op))
+#define XED_OP_NAME(ins, op) \
+  xed_operand_name(xed_inst_operand(xed_decoded_inst_inst(ins), op))
 
 #define XED_INS_Nop(ins) (XED_INS_Category(ins)) == XED_CATEGORY_NOP || XED_INS_Category(ins) == XED_CATEGORY_WIDENOP)
 #define XED_INS_LEA(ins) (XED_INS_Opcode(ins)) == XO(LEA))
 #define XED_INS_Opcode(ins) xed_decoded_inst_get_iclass(ins)
 #define XED_INS_Category(ins) xed_decoded_inst_get_category(ins)
 #define XED_INS_IsAtomicUpdate(ins) xed_decoded_inst_get_attribute(ins), XED_ATTRIBUTE_LOCKED)
-//FIXME: Check if REPs are translated correctly
+// FIXME: Check if REPs are translated correctly
 #define XED_INS_IsRep(ins) xed_decoded_inst_get_attribute(ins), XED_ATTRIBUTE_REP)
-#define XED_INS_HasRealRep(ins) xed_operand_values_has_real_rep(xed_decoded_inst_operands((xed_decoded_inst_t *)ins))
+#define XED_INS_HasRealRep(ins)    \
+  xed_operand_values_has_real_rep( \
+    xed_decoded_inst_operands((xed_decoded_inst_t*)ins))
 #define XED_INS_OperandCount(ins) xed_decoded_inst_noperands(ins)
 #define XED_INS_OperandIsImmediate(ins, op) XED_IS_IMM(ins, op)
-#define XED_INS_OperandRead(ins, op) xed_operand_read(xed_inst_operand(xed_decoded_inst_inst(ins), op))
-#define XED_INS_OperandWritten(ins, op) XED_INS_OperandIsMemory(ins, op) ? xed_decoded_inst_mem_written(ins, op) : xed_operand_written(xed_inst_operand(xed_decoded_inst_inst(ins), op))
-#define XED_INS_OperandReadOnly(ins, op) (XED_INS_OperandRead(ins, op) && !XED_INS_OperandWritten(ins, op))
-#define XED_INS_OperandWrittenOnly(ins, op) (!XED_INS_OperandRead(ins, op) && XED_INS_OperandWritten(ins, op))
-#define XED_INS_OperandIsReg(ins, op) xed_operand_is_register(xed_operand_name(xed_inst_operand(xed_decoded_inst_inst(ins), op)))
+#define XED_INS_OperandRead(ins, op) \
+  xed_operand_read(xed_inst_operand(xed_decoded_inst_inst(ins), op))
+#define XED_INS_OperandWritten(ins, op)     \
+  XED_INS_OperandIsMemory(ins, op) ?        \
+    xed_decoded_inst_mem_written(ins, op) : \
+    xed_operand_written(xed_inst_operand(xed_decoded_inst_inst(ins), op))
+#define XED_INS_OperandReadOnly(ins, op) \
+  (XED_INS_OperandRead(ins, op) && !XED_INS_OperandWritten(ins, op))
+#define XED_INS_OperandWrittenOnly(ins, op) \
+  (!XED_INS_OperandRead(ins, op) && XED_INS_OperandWritten(ins, op))
+#define XED_INS_OperandIsReg(ins, op) \
+  xed_operand_is_register(            \
+    xed_operand_name(xed_inst_operand(xed_decoded_inst_inst(ins), op)))
 #define XED_INS_OperandIsMemory(ins, op) XED_MEM(ins, op)
 //((xed_decoded_inst_mem_read(ins, op) | xed_decoded_inst_mem_written(ins, op)))
 #define XED_INS_IsMemory(ins) (xed_decoded_inst_number_of_memory_operands(ins))
-#define XED_INS_OperandReg(ins, op) xed_decoded_inst_get_reg(ins, xed_operand_name (xed_inst_operand(xed_decoded_inst_inst(ins), op)))
-#define XED_INS_OperandMemoryBaseReg(ins, op) xed_decoded_inst_get_base_reg(ins, op)
-#define XED_INS_OperandMemoryIndexReg(ins, op) xed_decoded_inst_get_index_reg(ins, op)
-//#define XED_INS_OperandMemoryDisplacement(ins, op) xed_operand_values_get_displacement_for_memop(ins, op)
+#define XED_INS_OperandReg(ins, op) \
+  xed_decoded_inst_get_reg(         \
+    ins, xed_operand_name(xed_inst_operand(xed_decoded_inst_inst(ins), op)))
+#define XED_INS_OperandMemoryBaseReg(ins, op) \
+  xed_decoded_inst_get_base_reg(ins, op)
+#define XED_INS_OperandMemoryIndexReg(ins, op) \
+  xed_decoded_inst_get_index_reg(ins, op)
+//#define XED_INS_OperandMemoryDisplacement(ins, op)
+// xed_operand_values_get_displacement_for_memop(ins, op)
 #define XED_INS_OperandMemoryScale(ins, op) (XED_INS_OperandWidth(ins, op) >> 3)
-#define XED_INS_LockPrefix(ins) xed_decoded_inst_get_attribute(ins, XED_ATTRIBUTE_LOCKED)
-#define XED_INS_OperandWidth(ins, op) xed_decoded_inst_operand_length_bits(ins, op)
+#define XED_INS_LockPrefix(ins) \
+  xed_decoded_inst_get_attribute(ins, XED_ATTRIBUTE_LOCKED)
+#define XED_INS_OperandWidth(ins, op) \
+  xed_decoded_inst_operand_length_bits(ins, op)
 #define XED_INS_MemoryOperandIsRead(ins, op) XED_MEM_READ(ins, op)
 #define XED_INS_MemoryOperandIsWritten(ins, op) XED_MEM_WRITTEN(ins, op)
-#define XED_INS_MemoryOperandCount(ins) xed_decoded_inst_number_of_memory_operands(ins)
+#define XED_INS_MemoryOperandCount(ins) \
+  xed_decoded_inst_number_of_memory_operands(ins)
 #define XED_INS_IsDirectBranch(ins) xed3_operand_get_brdisp_width(ins)
 #define XED_INS_Size(ins) xed_decoded_inst_get_length(ins)
 #define XED_INS_Valid(ins) xed_decoded_inst_valid(ins)
-/* Just like PIN we break BBLs on a number of additional instructions such as REP */
+/* Just like PIN we break BBLs on a number of additional instructions such as
+ * REP */
 #define XED_INS_ChangeControlFlow(ins) (XED_INS_Category(ins) == XC(COND_BR) || XED_INS_Category(ins) == XC(UNCOND_BR) || XED_INS_Category(ins) == XC(CALL) || XED_INS_Category(ins) == XC(RET) || XED_INS_Category(ins) == XC(SYSCALL) || XED_INS_Category(ins) == XC(SYSRET) || XED_INS_Opcode(ins) == XO(CPUID) || XED_INS_Opcode(ins) == XO(POPF) || XED_INS_Opcode(ins) == XO(POPFD) || XED_INS_Opcode(ins) == XO(POPFQ) || XED_INS_IsRep(ins)
 #define REG_FullRegName(reg) xed_get_largest_enclosing_register(reg)
 
-#define XED_INS_Mnemonic(ins) std::string(xed_iclass_enum_t2str(xed_decoded_inst_get_iclass(ins)))
-#define XED_IS_REG(ins, op)(XED_OP_NAME(ins, op) >= XED_OPERAND_REG0 && XED_OP_NAME(ins, op) <= XED_OPERAND_REG8)
-#define XED_MEM(ins, op)(XED_OP_NAME(ins, op) == XED_OPERAND_MEM0 || XED_OP_NAME(ins, op) == XED_OPERAND_MEM1)
-#define XED_LEA(ins, op)(XED_OP_NAME(ins, op) == XED_OPERAND_AGEN)
-#define XED_IS_IMM(ins, op)(XED_OP_NAME(ins, op) == XED_OPERAND_IMM0 || XED_OP_NAME(ins, op) == XED_OPERAND_IMM1)
+#define XED_INS_Mnemonic(ins) \
+  std::string(xed_iclass_enum_t2str(xed_decoded_inst_get_iclass(ins)))
+#define XED_IS_REG(ins, op)                    \
+  (XED_OP_NAME(ins, op) >= XED_OPERAND_REG0 && \
+   XED_OP_NAME(ins, op) <= XED_OPERAND_REG8)
+#define XED_MEM(ins, op)                       \
+  (XED_OP_NAME(ins, op) == XED_OPERAND_MEM0 || \
+   XED_OP_NAME(ins, op) == XED_OPERAND_MEM1)
+#define XED_LEA(ins, op) (XED_OP_NAME(ins, op) == XED_OPERAND_AGEN)
+#define XED_IS_IMM(ins, op)                    \
+  (XED_OP_NAME(ins, op) == XED_OPERAND_IMM0 || \
+   XED_OP_NAME(ins, op) == XED_OPERAND_IMM1)
 #define XED_MEM_READ(ins, op) xed_decoded_inst_mem_read(ins, op)
 #define XED_MEM_WRITTEN(ins, op) xed_decoded_inst_mem_written(ins, op)
-#define XED_INS_MemoryReadSize(ins, op) xed_decoded_inst_get_memory_operand_length(ins, op)
+#define XED_INS_MemoryReadSize(ins, op) \
+  xed_decoded_inst_get_memory_operand_length(ins, op)
 #define XED_INS_MemoryWriteSize(ins, op) XED_INS_MemoryReadSize(ins, op)
 #define XED_INS_IsRet(ins) (XED_INS_Category(ins) == XED_CATEGORY_RET)
-//TODO: Double check that below works calls and branches
+// TODO: Double check that below works calls and branches
 #define XED_INS_IsDirectBranchOrCall(ins) XED_INS_IsDirectBranch(ins)
 #define XED_INS_IsIndirectBranchOrCall(ins) !XED_INS_IsDirectBranchOrCall(ins)
 #define XED_INS_IsSyscall(ins) (XED_INS_Category(ins) == XED_CATEGORY_SYSCALL)
 #define XED_INS_IsSysret(ins) (XED_INS_Category(ins) == XED_CATEGORY_SYSRET)
-#define XED_INS_IsInterrupt(ins) (XED_INS_Category(ins) == XED_CATEGORY_INTERRUPT)
+#define XED_INS_IsInterrupt(ins) \
+  (XED_INS_Category(ins) == XED_CATEGORY_INTERRUPT)
 
 #define XED_INS_IsVgather(ins) (XED_INS_Category(ins) == XED_CATEGORY_GATHER)
 #define XED_INS_IsVscatter(ins) (XED_INS_Category(ins) == XED_CATEGORY_SCATTER)
 #define XED_REG_Size(reg) (xed_get_register_width_bits(reg) >> 3)
-#define XED_REG_is_xmm_ymm_zmm(reg) (xed_reg_class(reg) == XED_REG_CLASS_XMM || xed_reg_class(reg) == XED_REG_CLASS_YMM || xed_reg_class(reg) == XED_REG_CLASS_ZMM)
+#define XED_REG_is_xmm_ymm_zmm(reg)           \
+  (xed_reg_class(reg) == XED_REG_CLASS_XMM || \
+   xed_reg_class(reg) == XED_REG_CLASS_YMM || \
+   xed_reg_class(reg) == XED_REG_CLASS_ZMM)
 #define XED_REG_is_xmm(reg) (xed_reg_class(reg) == XED_REG_CLASS_XMM)
 #define XED_REG_is_ymm(reg) (xed_reg_class(reg) == XED_REG_CLASS_YMM)
-//TODO: Check if mask is sufficient or if we need to check for K-mask reg
+// TODO: Check if mask is sufficient or if we need to check for K-mask reg
 #define XED_REG_is_k_mask(reg) (xed_reg_class(reg) == XED_REG_CLASS_MASK)
 #define XED_REG_is_gr32(reg) (xed_reg_class(reg) == XED_REG_CLASS_GPR32)
 #define XED_REG_is_gr64(reg) (xed_reg_class(reg) == XED_REG_CLASS_GPR64)
-//TODO: What is the difference between PINs REG_Size and REG_Width?
+// TODO: What is the difference between PINs REG_Size and REG_Width?
 #define XED_REG_Width(reg) xed_get_register_width_bits(reg)
 #define XED_REG_valid(reg) (xed_reg_class(reg) != XED_REG_CLASS_INVALID)
 #define XED_REG_StringShort(reg) xed_reg_enum_t2str(reg)
@@ -135,10 +164,10 @@ struct InstInfo {
 #define XED_REGWIDTH_512 512
 
 //#define REG_GR_BASE REG_RDI
-//Used in decoder.h. zsim (pin) requires REG_LAST whereas zsim_trace requires XED_REG_LAST
-//#define REG_LAST XED_REG_LAST
+// Used in decoder.h. zsim (pin) requires REG_LAST whereas zsim_trace requires
+// XED_REG_LAST #define REG_LAST XED_REG_LAST
 
-//XED expansion macros (enable us to type opcodes at a reasonable speed)
+// XED expansion macros (enable us to type opcodes at a reasonable speed)
 #define XC(cat) (XED_CATEGORY_##cat)
 #define XO(opcode) (XED_ICLASS_##opcode)
 

--- a/src/pin/pin_lib/pin_api_to_xed.h
+++ b/src/pin/pin_lib/pin_api_to_xed.h
@@ -1,0 +1,150 @@
+/* Copyright 2020 University of California Santa Cruz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/***************************************************************************************
+ * File         : pin/pin_lib/pin_api_to_xed.h
+ * Author       : Heiner Litz
+ * Date         : 05/15/2020
+ * Notes        : This code has been adapted from zsim which was released under
+ *                GNU General Public License as published by the Free Software
+ *                Foundation, version 2.
+ * Description  :
+ ***************************************************************************************/
+
+/*
+ * Wrapper file to enable support for different instruction decoders.
+ * Currently we support PIN (execution driven) and Intel xed (trace driven)
+ */
+
+#ifndef THIRD_PARTY_ZSIM_SRC_WRAPPED_PIN_H_
+#define THIRD_PARTY_ZSIM_SRC_WRAPPED_PIN_H_
+
+extern "C" {
+  #include "xed-interface.h"
+}
+
+enum class CustomOp : uint8_t {
+  NONE,
+  PREFETCH_CODE
+};
+
+struct InstInfo {
+  uint64_t pc;                    // instruction address
+  const xed_decoded_inst_t *ins;  // XED info
+  uint64_t pid;                   // process ID
+  uint64_t tid;                   // thread ID
+  uint64_t target;                // branch target
+  uint64_t mem_addr[2];           // memory addresses
+  bool mem_used[2];               // mem address usage flags
+  CustomOp custom_op;             // Special or non-x86 ISA instruction
+  bool taken;                     // branch taken
+  bool unknown_type;              // No available decode info (presents a nop)
+  bool valid;                     // True until the end of the sequence
+};
+
+#define XED_OP_NAME(ins, op) xed_operand_name(xed_inst_operand(xed_decoded_inst_inst(ins), op))
+
+#define XED_INS_Nop(ins) (XED_INS_Category(ins)) == XED_CATEGORY_NOP || XED_INS_Category(ins) == XED_CATEGORY_WIDENOP)
+#define XED_INS_LEA(ins) (XED_INS_Opcode(ins)) == XO(LEA))
+#define XED_INS_Opcode(ins) xed_decoded_inst_get_iclass(ins)
+#define XED_INS_Category(ins) xed_decoded_inst_get_category(ins)
+#define XED_INS_IsAtomicUpdate(ins) xed_decoded_inst_get_attribute(ins), XED_ATTRIBUTE_LOCKED)
+//FIXME: Check if REPs are translated correctly
+#define XED_INS_IsRep(ins) xed_decoded_inst_get_attribute(ins), XED_ATTRIBUTE_REP)
+#define XED_INS_HasRealRep(ins) xed_operand_values_has_real_rep(xed_decoded_inst_operands((xed_decoded_inst_t *)ins))
+#define XED_INS_OperandCount(ins) xed_decoded_inst_noperands(ins)
+#define XED_INS_OperandIsImmediate(ins, op) XED_IS_IMM(ins, op)
+#define XED_INS_OperandRead(ins, op) xed_operand_read(xed_inst_operand(xed_decoded_inst_inst(ins), op))
+#define XED_INS_OperandWritten(ins, op) XED_INS_OperandIsMemory(ins, op) ? xed_decoded_inst_mem_written(ins, op) : xed_operand_written(xed_inst_operand(xed_decoded_inst_inst(ins), op))
+#define XED_INS_OperandReadOnly(ins, op) (XED_INS_OperandRead(ins, op) && !XED_INS_OperandWritten(ins, op))
+#define XED_INS_OperandWrittenOnly(ins, op) (!XED_INS_OperandRead(ins, op) && XED_INS_OperandWritten(ins, op))
+#define XED_INS_OperandIsReg(ins, op) xed_operand_is_register(xed_operand_name(xed_inst_operand(xed_decoded_inst_inst(ins), op)))
+#define XED_INS_OperandIsMemory(ins, op) XED_MEM(ins, op)
+//((xed_decoded_inst_mem_read(ins, op) | xed_decoded_inst_mem_written(ins, op)))
+#define XED_INS_IsMemory(ins) (xed_decoded_inst_number_of_memory_operands(ins))
+#define XED_INS_OperandReg(ins, op) xed_decoded_inst_get_reg(ins, xed_operand_name (xed_inst_operand(xed_decoded_inst_inst(ins), op)))
+#define XED_INS_OperandMemoryBaseReg(ins, op) xed_decoded_inst_get_base_reg(ins, op)
+#define XED_INS_OperandMemoryIndexReg(ins, op) xed_decoded_inst_get_index_reg(ins, op)
+//#define XED_INS_OperandMemoryDisplacement(ins, op) xed_operand_values_get_displacement_for_memop(ins, op)
+#define XED_INS_OperandMemoryScale(ins, op) (XED_INS_OperandWidth(ins, op) >> 3)
+#define XED_INS_LockPrefix(ins) xed_decoded_inst_get_attribute(ins, XED_ATTRIBUTE_LOCKED)
+#define XED_INS_OperandWidth(ins, op) xed_decoded_inst_operand_length_bits(ins, op)
+#define XED_INS_MemoryOperandIsRead(ins, op) XED_MEM_READ(ins, op)
+#define XED_INS_MemoryOperandIsWritten(ins, op) XED_MEM_WRITTEN(ins, op)
+#define XED_INS_MemoryOperandCount(ins) xed_decoded_inst_number_of_memory_operands(ins)
+#define XED_INS_IsDirectBranch(ins) xed3_operand_get_brdisp_width(ins)
+#define XED_INS_Size(ins) xed_decoded_inst_get_length(ins)
+#define XED_INS_Valid(ins) xed_decoded_inst_valid(ins)
+/* Just like PIN we break BBLs on a number of additional instructions such as REP */
+#define XED_INS_ChangeControlFlow(ins) (XED_INS_Category(ins) == XC(COND_BR) || XED_INS_Category(ins) == XC(UNCOND_BR) || XED_INS_Category(ins) == XC(CALL) || XED_INS_Category(ins) == XC(RET) || XED_INS_Category(ins) == XC(SYSCALL) || XED_INS_Category(ins) == XC(SYSRET) || XED_INS_Opcode(ins) == XO(CPUID) || XED_INS_Opcode(ins) == XO(POPF) || XED_INS_Opcode(ins) == XO(POPFD) || XED_INS_Opcode(ins) == XO(POPFQ) || XED_INS_IsRep(ins)
+#define REG_FullRegName(reg) xed_get_largest_enclosing_register(reg)
+
+#define XED_INS_Mnemonic(ins) std::string(xed_iclass_enum_t2str(xed_decoded_inst_get_iclass(ins)))
+#define XED_IS_REG(ins, op)(XED_OP_NAME(ins, op) >= XED_OPERAND_REG0 && XED_OP_NAME(ins, op) <= XED_OPERAND_REG8)
+#define XED_MEM(ins, op)(XED_OP_NAME(ins, op) == XED_OPERAND_MEM0 || XED_OP_NAME(ins, op) == XED_OPERAND_MEM1)
+#define XED_LEA(ins, op)(XED_OP_NAME(ins, op) == XED_OPERAND_AGEN)
+#define XED_IS_IMM(ins, op)(XED_OP_NAME(ins, op) == XED_OPERAND_IMM0 || XED_OP_NAME(ins, op) == XED_OPERAND_IMM1)
+#define XED_MEM_READ(ins, op) xed_decoded_inst_mem_read(ins, op)
+#define XED_MEM_WRITTEN(ins, op) xed_decoded_inst_mem_written(ins, op)
+#define XED_INS_MemoryReadSize(ins, op) xed_decoded_inst_get_memory_operand_length(ins, op)
+#define XED_INS_MemoryWriteSize(ins, op) XED_INS_MemoryReadSize(ins, op)
+#define XED_INS_IsRet(ins) (XED_INS_Category(ins) == XED_CATEGORY_RET)
+//TODO: Double check that below works calls and branches
+#define XED_INS_IsDirectBranchOrCall(ins) XED_INS_IsDirectBranch(ins)
+#define XED_INS_IsIndirectBranchOrCall(ins) !XED_INS_IsDirectBranchOrCall(ins)
+#define XED_INS_IsSyscall(ins) (XED_INS_Category(ins) == XED_CATEGORY_SYSCALL)
+#define XED_INS_IsSysret(ins) (XED_INS_Category(ins) == XED_CATEGORY_SYSRET)
+#define XED_INS_IsInterrupt(ins) (XED_INS_Category(ins) == XED_CATEGORY_INTERRUPT)
+
+#define XED_INS_IsVgather(ins) (XED_INS_Category(ins) == XED_CATEGORY_GATHER)
+#define XED_INS_IsVscatter(ins) (XED_INS_Category(ins) == XED_CATEGORY_SCATTER)
+#define XED_REG_Size(reg) (xed_get_register_width_bits(reg) >> 3)
+#define XED_REG_is_xmm_ymm_zmm(reg) (xed_reg_class(reg) == XED_REG_CLASS_XMM || xed_reg_class(reg) == XED_REG_CLASS_YMM || xed_reg_class(reg) == XED_REG_CLASS_ZMM)
+#define XED_REG_is_xmm(reg) (xed_reg_class(reg) == XED_REG_CLASS_XMM)
+#define XED_REG_is_ymm(reg) (xed_reg_class(reg) == XED_REG_CLASS_YMM)
+//TODO: Check if mask is sufficient or if we need to check for K-mask reg
+#define XED_REG_is_k_mask(reg) (xed_reg_class(reg) == XED_REG_CLASS_MASK)
+#define XED_REG_is_gr32(reg) (xed_reg_class(reg) == XED_REG_CLASS_GPR32)
+#define XED_REG_is_gr64(reg) (xed_reg_class(reg) == XED_REG_CLASS_GPR64)
+//TODO: What is the difference between PINs REG_Size and REG_Width?
+#define XED_REG_Width(reg) xed_get_register_width_bits(reg)
+#define XED_REG_valid(reg) (xed_reg_class(reg) != XED_REG_CLASS_INVALID)
+#define XED_REG_StringShort(reg) xed_reg_enum_t2str(reg)
+#define XED_CATEGORY_StringShort(cat) xed_category_enum_t2str(cat)
+#define XED_REG_INVALID() XED_REG_INVALID
+#define XED_REGWIDTH_128 128
+#define XED_REGWIDTH_256 256
+#define XED_REGWIDTH_512 512
+
+//#define REG_GR_BASE REG_RDI
+//Used in decoder.h. zsim (pin) requires REG_LAST whereas zsim_trace requires XED_REG_LAST
+//#define REG_LAST XED_REG_LAST
+
+//XED expansion macros (enable us to type opcodes at a reasonable speed)
+#define XC(cat) (XED_CATEGORY_##cat)
+#define XO(opcode) (XED_ICLASS_##opcode)
+
+#define ADDRINT uint64_t
+#define THREADID uint32_t
+
+//#define BOOL bool
+
+#endif  // THIRD_PARTY_ZSIM_SRC_WRAPPED_PIN_H_

--- a/src/pin/pin_lib/x86_decoder.cc
+++ b/src/pin/pin_lib/x86_decoder.cc
@@ -1,0 +1,1871 @@
+/* Copyright 2020 HPS/SAFARI Research Groups
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <iostream>
+#include <set>
+#include <string>
+#include <unordered_map>
+
+#include "pin/pin_lib/pin_scarab_common_lib.h"
+
+using namespace std;
+
+/************************** Data Type Definitions *****************************/
+#define REG(x) SCARAB_REG_##x,
+typedef enum Reg_Id_struct {
+#include "isa/x86_regs.def"
+  SCARAB_NUM_REGS
+} Reg_Id;
+#undef REG
+
+#include "pin/pin_lib/x86_decoder.h"
+#include "gather_scatter_addresses.h"
+
+struct iclass_to_scarab {
+  int     opcode;
+  int     lane_width_bytes;
+  int     num_simd_lanes;
+  MemHint mem_hint;
+};
+
+enum Reg_Array_Id {
+  SRC_REGS,
+  DST_REGS,
+  LD1_ADDR_REGS,
+  LD2_ADDR_REGS,
+  ST_ADDR_REGS,
+  NUM_REG_ARRAYS
+};
+
+struct Reg_Array_Info {
+  size_t  array_offset;
+  uint8_t ctype_pin_inst::*num;
+  uint8_t                  max_num;
+};
+
+/**************************** Global Variables ********************************/
+// helper array used by add_reg()
+static Reg_Array_Info reg_array_infos[NUM_REG_ARRAYS] = {
+  {offsetof(ctype_pin_inst, src_regs), &ctype_pin_inst::num_src_regs,
+   MAX_SRC_REGS_NUM},
+  {offsetof(ctype_pin_inst, dst_regs), &ctype_pin_inst::num_dst_regs,
+   MAX_DST_REGS_NUM},
+  {offsetof(ctype_pin_inst, ld1_addr_regs), &ctype_pin_inst::num_ld1_addr_regs,
+   MAX_MEM_ADDR_REGS_NUM},
+  {offsetof(ctype_pin_inst, ld2_addr_regs), &ctype_pin_inst::num_ld2_addr_regs,
+   MAX_MEM_ADDR_REGS_NUM},
+  {offsetof(ctype_pin_inst, st_addr_regs), &ctype_pin_inst::num_st_addr_regs,
+   MAX_MEM_ADDR_REGS_NUM},
+};
+
+// maps for translation from pin to scarab
+uint8_t reg_compress_map[(int)XED_REG_LAST + 1] = {0};  // Assuming REG_INV is 0
+// Assuming OP_INV is 0
+iclass_to_scarab iclass_to_scarab_map[XED_ICLASS_LAST] = {{0}};
+
+std::ostream*         dec_err_ostream;
+
+/********************* Private Functions Prototypes ***************************/
+static void     add_reg(ctype_pin_inst* info, Reg_Array_Id id, uint8_t reg);
+static uint8_t  reg_compress(xed_reg_enum_t pin_reg, ADDRINT ip);
+void     init_reg_compress_map();
+void     init_pin_opcode_convert();
+
+/**************************** Public Functions ********************************/
+void init_x86_decoder(std::ostream* err_ostream) {
+  init_reg_compress_map();
+  init_pin_opcode_convert();
+  if(err_ostream) {
+    dec_err_ostream = err_ostream;
+  } else {
+    dec_err_ostream = &std::cout;
+  }
+}
+
+void fill_in_basic_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins) {
+  int category           = XED_INS_Category(ins);
+  info->size             = XED_INS_Size(ins);
+
+  info->true_op_type = XED_INS_Opcode(ins);
+  info->op_type = iclass_to_scarab_map[XED_INS_Opcode(ins)].opcode;
+  assert(XED_INS_Mnemonic(ins).size() < sizeof(info->pin_iclass));
+  strcpy(info->pin_iclass, XED_INS_Mnemonic(ins).c_str());
+
+  if((category == XED_CATEGORY_SSE) || (category == XED_CATEGORY_FCMOV) ||
+     (category == XED_CATEGORY_X87_ALU)) {
+    info->is_fp = 1;
+  }
+  info->is_string   = (category == XED_CATEGORY_STRINGOP);
+  info->is_call     = (category == XED_CATEGORY_CALL);
+  info->is_move     = (category == XED_CATEGORY_DATAXFER ||
+                   info->op_type == OP_MOV);
+  info->is_prefetch = (category == XED_CATEGORY_PREFETCH);
+  info->has_push    = (category == XED_CATEGORY_PUSH ||
+                    category == XED_CATEGORY_CALL);
+  info->has_pop     = (category == XED_CATEGORY_POP ||
+                   category == XED_CATEGORY_RET);
+  info->is_lock     = XED_INS_LockPrefix(ins);
+  info->is_repeat   = XED_INS_HasRealRep(ins);
+  info->is_gather_scatter = XED_INS_IsVgather(ins) || XED_INS_IsVscatter(ins);
+}
+
+uint32_t add_dependency_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins) {
+  uint32_t      max_op_width = 0;
+  const ADDRINT iaddr        = info->instruction_addr;
+  bool is_gather_or_scatter  = XED_INS_IsVgather(ins) || XED_INS_IsVscatter(ins);
+  info->ld_size = 0;
+  info->st_size = 0;
+  if(info->op_type != OP_NOP) {
+    //Iterate over reg operands separately
+    for(uint32_t ii = 0; ii < XED_INS_OperandCount(ins); ii++) {
+      if(XED_INS_OperandIsReg(ins, ii)) {
+        xed_reg_enum_t xed_reg = XED_INS_OperandReg(ins, ii);
+        uint8_t scarab_reg     = (uint8_t)reg_compress(xed_reg, iaddr);
+        bool    operandRead    = XED_INS_OperandRead(ins, ii);
+        bool    operandWritten = XED_INS_OperandWritten(ins, ii);
+        if(operandRead) {
+          add_reg(info, SRC_REGS, scarab_reg);
+        }
+        if(operandWritten) {
+          add_reg(info, DST_REGS, scarab_reg);
+        }
+        if(scarab_reg >= SCARAB_REG_FP0 && scarab_reg <= SCARAB_REG_FP7)
+          info->is_fp = TRUE;
+        if(scarab_reg != SCARAB_REG_ZPS) {
+          max_op_width = std::max(max_op_width, XED_INS_OperandWidth(ins, ii));
+        }
+        if(is_gather_or_scatter) {
+          set_gather_scatter_reg_operand_info(iaddr, xed_reg, operandRead,
+                                              operandWritten);
+        }
+      }
+      info->has_immediate |= XED_INS_OperandIsImmediate(ins, ii);
+      if(is_gather_or_scatter) {
+        assert(!(info->has_immediate));
+      }
+    }
+    //Memory Operands (iterate of Memory operands)
+    for(unsigned int ii = 0; ii < XED_INS_MemoryOperandCount(ins); ii++) {
+      //LEA
+      if(!XED_INS_MemoryOperandIsRead(ins, ii) && !XED_INS_MemoryOperandIsWritten(ins, ii)) {
+        assert(!is_gather_or_scatter);
+        uint8_t scarab_base_reg = (uint8_t)reg_compress(
+          XED_INS_OperandMemoryBaseReg(ins, ii), iaddr);
+        uint8_t scarab_index_reg = (uint8_t)reg_compress(
+          XED_INS_OperandMemoryIndexReg(ins, ii), iaddr);
+        add_reg(info, SRC_REGS, scarab_base_reg);
+        add_reg(info, SRC_REGS, scarab_index_reg);
+      }
+      else {
+        xed_reg_enum_t pin_base_reg = XED_INS_OperandMemoryBaseReg(ins, ii);
+        uint8_t scarab_base_reg  = (uint8_t)reg_compress(pin_base_reg, iaddr);
+        xed_reg_enum_t pin_index_reg = XED_INS_OperandMemoryIndexReg(ins, ii);
+        uint8_t scarab_index_reg = (uint8_t)reg_compress(pin_index_reg, iaddr);
+        if(is_gather_or_scatter) {
+          set_gather_scatter_memory_operand_info(
+            iaddr, pin_base_reg, pin_index_reg,
+            //XED_INS_OperandMemoryDisplacement(ins, ii),
+            XED_INS_OperandMemoryScale(ins, ii), XED_INS_OperandReadOnly(ins, ii),
+            XED_INS_OperandWrittenOnly(ins, ii));
+        }
+	if(XED_INS_MemoryOperandIsRead(ins, ii)) {
+	  assert(info->num_ld < MAX_LD_NUM);
+	  add_reg(info, (Reg_Array_Id)(LD1_ADDR_REGS + info->num_ld),
+                  scarab_base_reg);
+	  add_reg(info, (Reg_Array_Id)(LD1_ADDR_REGS + info->num_ld),
+                  scarab_index_reg);
+	  info->num_ld++;
+          //if the instruction has multiple mem accesses check if they have the same size
+          assert(info->ld_size == 0 || info->ld_size == XED_INS_MemoryReadSize(ins, ii));
+          info->ld_size = XED_INS_MemoryReadSize(ins, ii);
+	}
+	if(XED_INS_MemoryOperandIsWritten(ins, ii)) {
+	  assert(info->num_st < MAX_ST_NUM);
+	  add_reg(info, (Reg_Array_Id)(ST_ADDR_REGS + info->num_st), scarab_base_reg);
+	  add_reg(info, (Reg_Array_Id)(ST_ADDR_REGS + info->num_st), scarab_index_reg);
+	  info->num_st++;
+          //if the instruction has multiple mem accesses check if they have the same size
+          assert(info->st_size == 0 || info->st_size == XED_INS_MemoryWriteSize(ins, ii));
+          info->st_size = XED_INS_MemoryWriteSize(ins, ii);
+	}
+      }
+      info->has_immediate |= XED_INS_OperandIsImmediate(ins, ii);
+      if(is_gather_or_scatter) {
+        assert(!(info->has_immediate));
+      }
+    }
+  }
+  return max_op_width;
+}
+
+void fill_in_simd_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins,
+                       uint32_t max_op_width) {
+  iclass_to_scarab iclass_info = iclass_to_scarab_map[XED_INS_Opcode(ins)];
+  if(info->op_type != OP_INV) {
+    assert(max_op_width % 8 == 0);
+    int lane_width_bytes = iclass_info.lane_width_bytes;
+    int num_simd_lanes   = iclass_info.num_simd_lanes;
+    if(lane_width_bytes == -1) {
+      info->lane_width_bytes = max_op_width / 8;
+      info->num_simd_lanes   = 1;
+    } else if(num_simd_lanes == -1) {
+      info->lane_width_bytes = lane_width_bytes;
+      assert((max_op_width / 8) % lane_width_bytes == 0);
+      info->num_simd_lanes = max_op_width / 8 / lane_width_bytes;
+    } else {
+      info->lane_width_bytes = lane_width_bytes;
+      info->num_simd_lanes   = num_simd_lanes;
+    }
+  }
+
+  info->is_simd = 0;
+  for(int i = 0; i < info->num_src_regs; ++i) {
+    if(info->src_regs[i] >= SCARAB_REG_ZMM0 &&
+       info->src_regs[i] <= SCARAB_REG_ZMM31) {
+      info->is_simd = 1;
+      return;
+    }
+  }
+  for(int i = 0; i < info->num_dst_regs; ++i) {
+    if(info->dst_regs[i] >= SCARAB_REG_ZMM0 &&
+       info->dst_regs[i] <= SCARAB_REG_ZMM31) {
+      info->is_simd = 1;
+      return;
+    }
+  }
+}
+
+void apply_x87_bug_workaround(ctype_pin_inst* info, const xed_decoded_inst_t* ins) {
+  // Workaround for a bug in Pin 2.8, see
+  // http://tech.groups.yahoo.com/group/pinheads/message/6082
+  if(pops_x87_stack(XED_INS_Opcode(ins)) && info->num_dst_regs == 1 &&
+     info->dst_regs[0] == SCARAB_REG_FP0) {
+    int other_reg = SCARAB_REG_FP0;
+    for(int i = 0; i < info->num_src_regs; ++i) {
+      if(info->src_regs[i] != SCARAB_REG_FP0) {
+        assert(other_reg == SCARAB_REG_FP0);
+        other_reg = info->src_regs[i];
+      }
+    }
+    // not checking for other_reg != SCARAB_REG_FP0 because sometimes the
+    // compiler may use FSTP ST0 or smth to simply pop the x87 stack
+    info->dst_regs[0] = other_reg;
+  }
+}
+
+void fill_in_cf_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins) {
+  int category  = XED_INS_Category(ins);
+  info->cf_type = NOT_CF;
+
+  if(XED_INS_IsRet(ins)) {
+    info->cf_type = CF_RET;
+  } else if(XED_INS_IsIndirectBranchOrCall(ins)) {
+    // indirect
+    if(category == XED_CATEGORY_UNCOND_BR)
+      info->cf_type = CF_IBR;
+    else if(category == XED_CATEGORY_COND_BR)
+      info->cf_type = CF_ICO;  // ICBR not supported by Scarab, so map it to ICO
+    else if(category == XED_CATEGORY_CALL)
+      info->cf_type = CF_ICALL;
+
+  } else if(XED_INS_IsDirectBranchOrCall(ins)) {
+    // direct
+    if(category == XED_CATEGORY_UNCOND_BR)
+      info->cf_type = CF_BR;
+    else if(category == XED_CATEGORY_COND_BR)
+      info->cf_type = CF_CBR;
+    else if(category == XED_CATEGORY_CALL)
+      info->cf_type = CF_CALL;
+  } else if(XED_INS_IsSyscall(ins) || XED_INS_IsSysret(ins) || XED_INS_IsInterrupt(ins)) {
+    info->cf_type = CF_SYS;
+  }
+
+  info->is_ifetch_barrier = is_ifetch_barrier(ins);
+}
+
+void print_err_if_invalid(ctype_pin_inst* info, const xed_decoded_inst_t* ins) {
+  if(info->op_type == OP_INV) {
+    (*dec_err_ostream)
+      << "Unmapped instruction at "
+      << "EIP: " << std::hex << info->instruction_addr
+      << ", opcode: " << XED_INS_Mnemonic(ins)
+      << ", category: " << std::string(xed_category_enum_t2str(XED_INS_Category(ins))) << std::dec
+      << ", opcode index: " << XED_INS_Opcode(ins)
+      << ", hasrealrep: " << (int)info->is_repeat
+      << ", is_lock: " << (int)info->is_lock
+      << ", num_ld: " << (int)info->num_ld << ", num_st: " << (int)info->num_st
+      << ", num_src_regs: " << (int)info->num_src_regs
+      << ", num_dst_regs: " << (int)info->num_dst_regs
+      << ", num_ld1_addr_regs: " << (int)info->num_ld1_addr_regs
+      << ", num_ld2_addr_regs: " << (int)info->num_ld2_addr_regs
+      << ", num_st_addr_regs: " << (int)info->num_st_addr_regs
+      << ", num_simd_lanes: " << (int)info->num_simd_lanes
+      << ", lane_width_bytes: " << (int)info->lane_width_bytes
+      << ". Look at README in pin/pin_lib on how to map new instructions";
+      dec_err_ostream->flush();
+  }
+}
+
+uint8_t is_ifetch_barrier(const xed_decoded_inst_t* ins) {
+  int category = XED_INS_Category(ins);
+  int opcode   = XED_INS_Opcode(ins);
+  return (category == XED_CATEGORY_IO) ||
+         (category == XED_CATEGORY_INTERRUPT) ||
+         (category == XED_CATEGORY_VTX) || (category == XED_CATEGORY_SYSTEM) ||
+         (category == XED_CATEGORY_SYSCALL) ||
+         (category == XED_CATEGORY_SYSRET) || (opcode == XED_ICLASS_PAUSE);
+}
+
+static compressed_reg_t reg_compress(xed_reg_enum_t pin_reg, ADDRINT ip) {
+  compressed_reg_t result = reg_compress_map[pin_reg];
+  if(result == SCARAB_REG_INV && (int)pin_reg != 0) {
+    (*dec_err_ostream) << "Invalid register operand "
+      		       << std::string(xed_reg_enum_t2str(pin_reg))
+                             << " at: " << std::hex << ip << std::endl;
+  }
+  return result;
+}
+
+/*************************** Private Functions  *******************************/
+static void add_reg(ctype_pin_inst* info, Reg_Array_Id id, uint8_t reg) {
+  if(reg == SCARAB_REG_INV)
+    return;
+  if(reg >= SCARAB_REG_CS && reg <= SCARAB_REG_RIP)
+    return;  // ignoring EIP and segment regs
+
+  uint8_t* array = ((uint8_t*)info) + reg_array_infos[id].array_offset;
+  uint8_t ctype_pin_inst::*num_ptr = reg_array_infos[id].num;
+  //  uint8_t * num   = &(info->*num_ptr);
+  uint8_t max_num = reg_array_infos[id].max_num;
+  assert(id < NUM_REG_ARRAYS);
+  assert(info->*num_ptr < max_num);
+  array[info->*num_ptr] = reg;
+  (info->*num_ptr)++;
+}
+
+void init_reg_compress_map(void) {
+  assert(SCARAB_REG_INV == 0);
+
+  // Makes sure src_regs is wide enough for Scarab registers.
+  assert(SCARAB_NUM_REGS < (1 << (sizeof(compressed_reg_t) * 8)));
+
+  reg_compress_map[0]                      = 0;
+  reg_compress_map[(int)XED_REG_RDI]       = SCARAB_REG_RDI;
+  reg_compress_map[(int)XED_REG_EDI]       = SCARAB_REG_RDI;
+  reg_compress_map[(int)XED_REG_ESI]       = SCARAB_REG_RSI;
+  reg_compress_map[(int)XED_REG_RSI]       = SCARAB_REG_RSI;
+  reg_compress_map[(int)XED_REG_EBP]       = SCARAB_REG_RBP;
+  reg_compress_map[(int)XED_REG_RBP]       = SCARAB_REG_RBP;
+  reg_compress_map[(int)XED_REG_ESP]       = SCARAB_REG_RSP;
+  reg_compress_map[(int)XED_REG_RSP]       = SCARAB_REG_RSP;
+  reg_compress_map[(int)XED_REG_EBX]       = SCARAB_REG_RBX;
+  reg_compress_map[(int)XED_REG_RBX]       = SCARAB_REG_RBX;
+  reg_compress_map[(int)XED_REG_EDX]       = SCARAB_REG_RDX;
+  reg_compress_map[(int)XED_REG_RDX]       = SCARAB_REG_RDX;
+  reg_compress_map[(int)XED_REG_ECX]       = SCARAB_REG_RCX;
+  reg_compress_map[(int)XED_REG_RCX]       = SCARAB_REG_RCX;
+  reg_compress_map[(int)XED_REG_EAX]       = SCARAB_REG_RAX;
+  reg_compress_map[(int)XED_REG_RAX]       = SCARAB_REG_RAX;
+  //  reg_compress_map[(int)XED_REG_GR_LAST]   = SCARAB_REG_RAX;
+  reg_compress_map[(int)XED_REG_FSBASE]  = SCARAB_REG_CS;
+  //todo: Not sure about the next
+  reg_compress_map[(int)XED_REG_GSBASE]  = SCARAB_REG_CS;
+  reg_compress_map[(int)XED_REG_CS]    = SCARAB_REG_CS;
+  reg_compress_map[(int)XED_REG_SS]    = SCARAB_REG_SS;
+  reg_compress_map[(int)XED_REG_DS]    = SCARAB_REG_DS;
+  reg_compress_map[(int)XED_REG_ES]    = SCARAB_REG_ES;
+  reg_compress_map[(int)XED_REG_FS]    = SCARAB_REG_FS;
+  reg_compress_map[(int)XED_REG_GS]    = SCARAB_REG_GS;
+  //reg_compress_map[(int)XED_REG_SEG_LAST]  = SCARAB_REG_GS;
+  // Treating any flag dependency as ZPS because we could not
+  // get finer grain dependicies from PIN
+  reg_compress_map[(int)XED_REG_EFLAGS]   = SCARAB_REG_ZPS;
+  reg_compress_map[(int)XED_REG_RFLAGS]   = SCARAB_REG_ZPS;
+  reg_compress_map[(int)XED_REG_EIP]      = SCARAB_REG_RIP;
+  reg_compress_map[(int)XED_REG_RIP] = SCARAB_REG_RIP;
+  reg_compress_map[(int)XED_REG_AL]       = SCARAB_REG_RAX;
+  reg_compress_map[(int)XED_REG_AH]       = SCARAB_REG_RAX;
+  reg_compress_map[(int)XED_REG_AX]       = SCARAB_REG_RAX;
+  reg_compress_map[(int)XED_REG_CL]       = SCARAB_REG_RCX;
+  reg_compress_map[(int)XED_REG_CH]       = SCARAB_REG_RCX;
+  reg_compress_map[(int)XED_REG_CX]       = SCARAB_REG_RCX;
+  reg_compress_map[(int)XED_REG_DL]       = SCARAB_REG_RDX;
+  reg_compress_map[(int)XED_REG_DH]       = SCARAB_REG_RDX;
+  reg_compress_map[(int)XED_REG_DX]       = SCARAB_REG_RDX;
+  reg_compress_map[(int)XED_REG_BL]       = SCARAB_REG_RBX;
+  reg_compress_map[(int)XED_REG_BH]       = SCARAB_REG_RBX;
+  reg_compress_map[(int)XED_REG_BX]       = SCARAB_REG_RBX;
+  reg_compress_map[(int)XED_REG_BP]       = SCARAB_REG_RBX;
+  reg_compress_map[(int)XED_REG_SI]       = SCARAB_REG_RSI;
+  reg_compress_map[(int)XED_REG_DI]       = SCARAB_REG_RDI;
+  reg_compress_map[(int)XED_REG_SP]       = SCARAB_REG_RSP;
+  reg_compress_map[(int)XED_REG_FLAGS]    = SCARAB_REG_ZPS;
+  reg_compress_map[(int)XED_REG_IP]       = SCARAB_REG_RIP;
+  reg_compress_map[(int)XED_REG_MMX_FIRST]  = SCARAB_REG_ZMM0;
+  reg_compress_map[(int)XED_REG_MMX0]      = SCARAB_REG_ZMM0;
+  reg_compress_map[(int)XED_REG_MMX1]      = SCARAB_REG_ZMM1;
+  reg_compress_map[(int)XED_REG_MMX2]      = SCARAB_REG_ZMM2;
+  reg_compress_map[(int)XED_REG_MMX3]      = SCARAB_REG_ZMM3;
+  reg_compress_map[(int)XED_REG_MMX4]      = SCARAB_REG_ZMM4;
+  reg_compress_map[(int)XED_REG_MMX5]      = SCARAB_REG_ZMM5;
+  reg_compress_map[(int)XED_REG_MMX6]      = SCARAB_REG_ZMM6;
+  reg_compress_map[(int)XED_REG_MMX7]      = SCARAB_REG_ZMM7;
+  reg_compress_map[(int)XED_REG_MMX_LAST]  = SCARAB_REG_ZMM7;
+
+  reg_compress_map[(int)XED_REG_XMM_FIRST]       = SCARAB_REG_ZMM0;
+  reg_compress_map[(int)XED_REG_XMM0]            = SCARAB_REG_ZMM0;
+  reg_compress_map[(int)XED_REG_XMM1]            = SCARAB_REG_ZMM1;
+  reg_compress_map[(int)XED_REG_XMM2]            = SCARAB_REG_ZMM2;
+  reg_compress_map[(int)XED_REG_XMM3]            = SCARAB_REG_ZMM3;
+  reg_compress_map[(int)XED_REG_XMM4]            = SCARAB_REG_ZMM4;
+  reg_compress_map[(int)XED_REG_XMM5]            = SCARAB_REG_ZMM5;
+  reg_compress_map[(int)XED_REG_XMM6]            = SCARAB_REG_ZMM6;
+  reg_compress_map[(int)XED_REG_XMM7]            = SCARAB_REG_ZMM7;
+  //reg_compress_map[(int)XED_REG_XMM_SSE_LAST]    = SCARAB_REG_ZMM7;
+  //reg_compress_map[(int)XED_REG_XMM_AVX_LAST]    = SCARAB_REG_ZMM7;
+  //reg_compress_map[(int)XED_REG_XMM_AVX512_LAST] = SCARAB_REG_ZMM7;
+  reg_compress_map[(int)XED_REG_XMM_LAST]        = SCARAB_REG_ZMM7;
+
+  reg_compress_map[(int)XED_REG_YMM_FIRST]        = SCARAB_REG_ZMM0;
+  reg_compress_map[(int)XED_REG_YMM0]            = SCARAB_REG_ZMM0;
+  reg_compress_map[(int)XED_REG_YMM1]            = SCARAB_REG_ZMM1;
+  reg_compress_map[(int)XED_REG_YMM2]            = SCARAB_REG_ZMM2;
+  reg_compress_map[(int)XED_REG_YMM3]            = SCARAB_REG_ZMM3;
+  reg_compress_map[(int)XED_REG_YMM4]            = SCARAB_REG_ZMM4;
+  reg_compress_map[(int)XED_REG_YMM5]            = SCARAB_REG_ZMM5;
+  reg_compress_map[(int)XED_REG_YMM6]            = SCARAB_REG_ZMM6;
+  reg_compress_map[(int)XED_REG_YMM7]            = SCARAB_REG_ZMM7;
+  //reg_compress_map[(int)XED_REG_YMM_AVX_LAST]    = SCARAB_REG_ZMM7;
+  //reg_compress_map[(int)XED_REG_YMM_AVX512_LAST] = SCARAB_REG_ZMM7;
+  reg_compress_map[(int)XED_REG_YMM_LAST]        = SCARAB_REG_ZMM7;
+
+  reg_compress_map[(int)XED_REG_ZMM_FIRST]              = SCARAB_REG_ZMM0;
+  reg_compress_map[(int)XED_REG_ZMM0]                  = SCARAB_REG_ZMM0;
+  reg_compress_map[(int)XED_REG_ZMM1]                  = SCARAB_REG_ZMM1;
+  reg_compress_map[(int)XED_REG_ZMM2]                  = SCARAB_REG_ZMM2;
+  reg_compress_map[(int)XED_REG_ZMM3]                  = SCARAB_REG_ZMM3;
+  reg_compress_map[(int)XED_REG_ZMM4]                  = SCARAB_REG_ZMM4;
+  reg_compress_map[(int)XED_REG_ZMM5]                  = SCARAB_REG_ZMM5;
+  reg_compress_map[(int)XED_REG_ZMM6]                  = SCARAB_REG_ZMM6;
+  reg_compress_map[(int)XED_REG_ZMM7]                  = SCARAB_REG_ZMM7;
+  //reg_compress_map[(int)XED_REG_ZMM_AVX512_SPLIT_LAST] = SCARAB_REG_ZMM7;
+  //reg_compress_map[(int)XED_REG_ZMM_AVX512_LAST]       = SCARAB_REG_ZMM7;
+  reg_compress_map[(int)XED_REG_ZMM_LAST]              = SCARAB_REG_ZMM7;
+
+  //reg_compress_map[(int)XED_REG_MASK_FIRST]             = SCARAB_REG_K0;
+  //reg_compress_map[(int)XED_REG_IMPLICIT_FULL_MASK] = SCARAB_REG_K0;
+  reg_compress_map[(int)XED_REG_K0]                 = SCARAB_REG_K0;
+  reg_compress_map[(int)XED_REG_K1]                 = SCARAB_REG_K1;
+  reg_compress_map[(int)XED_REG_K2]                 = SCARAB_REG_K2;
+  reg_compress_map[(int)XED_REG_K3]                 = SCARAB_REG_K3;
+  reg_compress_map[(int)XED_REG_K4]                 = SCARAB_REG_K4;
+  reg_compress_map[(int)XED_REG_K5]                 = SCARAB_REG_K5;
+  reg_compress_map[(int)XED_REG_K6]                 = SCARAB_REG_K6;
+  reg_compress_map[(int)XED_REG_K7]                 = SCARAB_REG_K7;
+  //reg_compress_map[(int)XED_REG_MASK_LAST]             = SCARAB_REG_K7;
+
+  reg_compress_map[(int)XED_REG_MXCSR]     = SCARAB_REG_OTHER;
+  //reg_compress_map[(int)XED_REG_MXCSRMASK] = SCARAB_REG_OTHER;
+
+  reg_compress_map[(int)XED_REG_X87CONTROL] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_X87STATUS] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_X87TAG] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_X87PUSH] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_X87POP] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_X87POP2] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_X87OPCODE] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_X87LASTCS] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_X87LASTIP] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_X87LASTDS] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_X87LASTDP] = SCARAB_REG_OTHER;
+  /*
+  reg_compress_map[(int)XED_REG_FPST_BASE]     = SCARAB_REG_FPCW;
+  reg_compress_map[(int)XED_REG_FPSTATUS_BASE] = SCARAB_REG_FPCW;
+  reg_compress_map[(int)XED_REG_FPCW]          = SCARAB_REG_FPCW;
+  reg_compress_map[(int)XED_REG_FPSW]          = SCARAB_REG_FPST;
+  reg_compress_map[(int)XED_REG_FPTAG]         = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_FPIP_OFF]      = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_FPIP_SEL]      = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_FPOPCODE]      = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_FPDP_OFF]      = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_FPDP_SEL]      = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_FPSTATUS_LAST] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_FPTAG_FULL]    = SCARAB_REG_OTHER;
+  */
+  //  reg_compress_map[(int)XED_REG_ST_BASE]   = SCARAB_REG_FP0;
+  reg_compress_map[(int)XED_REG_ST0]       = SCARAB_REG_FP0;
+  reg_compress_map[(int)XED_REG_ST1]       = SCARAB_REG_FP1;
+  reg_compress_map[(int)XED_REG_ST2]       = SCARAB_REG_FP2;
+  reg_compress_map[(int)XED_REG_ST3]       = SCARAB_REG_FP3;
+  reg_compress_map[(int)XED_REG_ST4]       = SCARAB_REG_FP4;
+  reg_compress_map[(int)XED_REG_ST5]       = SCARAB_REG_FP5;
+  reg_compress_map[(int)XED_REG_ST6]       = SCARAB_REG_FP6;
+  reg_compress_map[(int)XED_REG_ST7]       = SCARAB_REG_FP7;
+  //reg_compress_map[(int)XED_REG_ST_LAST]   = SCARAB_REG_FP7;
+  //reg_compress_map[(int)XED_REG_FPST_LAST] = SCARAB_REG_FP7;
+
+  //reg_compress_map[(int)XED_REG_DR_BASE] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_DR0]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_DR1]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_DR2]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_DR3]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_DR4]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_DR5]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_DR6]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_DR7]     = SCARAB_REG_OTHER;
+  //reg_compress_map[(int)XED_REG_DR_LAST] = SCARAB_REG_OTHER;
+
+  //reg_compress_map[(int)XED_REG_CR_BASE] = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_TSC]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_TSCAUX]  = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_XCR0]    = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR0]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR1]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR2]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR3]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR4]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR5]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR6]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR7]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR8]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR9]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR10]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR11]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR12]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR13]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR14]     = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_CR15]     = SCARAB_REG_OTHER;
+  //reg_compress_map[(int)XED_REG_CR_LAST] = SCARAB_REG_OTHER;
+  //reg_compress_map[(int)XED_REG_TSSR]    = SCARAB_REG_OTHER;
+  reg_compress_map[(int)XED_REG_LDTR]    = SCARAB_REG_OTHER;
+  //reg_compress_map[(int)XED_REG_TR_BASE] = SCARAB_REG_OTHER;
+  //reg_compress_map[(int)XED_REG_TR]      = SCARAB_REG_OTHER;
+  //reg_compress_map[(int)XED_REG_TR3]     = SCARAB_REG_OTHER;
+  //reg_compress_map[(int)XED_REG_TR4]     = SCARAB_REG_OTHER;
+  //reg_compress_map[(int)XED_REG_TR5]     = SCARAB_REG_OTHER;
+  //reg_compress_map[(int)XED_REG_TR6]     = SCARAB_REG_OTHER;
+  //reg_compress_map[(int)XED_REG_TR7]     = SCARAB_REG_OTHER;
+  //reg_compress_map[(int)XED_REG_TR_LAST] = SCARAB_REG_OTHER;
+
+  reg_compress_map[(int)XED_REG_STACKPUSH] = SCARAB_REG_RSP;
+  reg_compress_map[(int)XED_REG_STACKPOP] = SCARAB_REG_RSP;
+  reg_compress_map[(int)XED_REG_RDI]     = SCARAB_REG_RDI;
+  reg_compress_map[(int)XED_REG_RSI]     = SCARAB_REG_RSI;
+  reg_compress_map[(int)XED_REG_RBP]     = SCARAB_REG_RBP;
+  reg_compress_map[(int)XED_REG_RSP]     = SCARAB_REG_RSP;
+  reg_compress_map[(int)XED_REG_RBX]     = SCARAB_REG_RBX;
+  reg_compress_map[(int)XED_REG_RDX]     = SCARAB_REG_RDX;
+  reg_compress_map[(int)XED_REG_RCX]     = SCARAB_REG_RCX;
+  reg_compress_map[(int)XED_REG_RAX]     = SCARAB_REG_RAX;
+  reg_compress_map[(int)XED_REG_R8]      = SCARAB_REG_R8;
+  reg_compress_map[(int)XED_REG_R9]      = SCARAB_REG_R9;
+  reg_compress_map[(int)XED_REG_R10]     = SCARAB_REG_R10;
+  reg_compress_map[(int)XED_REG_R11]     = SCARAB_REG_R11;
+  reg_compress_map[(int)XED_REG_R12]     = SCARAB_REG_R12;
+  reg_compress_map[(int)XED_REG_R13]     = SCARAB_REG_R13;
+  reg_compress_map[(int)XED_REG_R14]     = SCARAB_REG_R14;
+  reg_compress_map[(int)XED_REG_R15]     = SCARAB_REG_R15;
+  //reg_compress_map[(int)XED_REG_GR_LAST] = SCARAB_REG_R15;
+  reg_compress_map[(int)XED_REG_RFLAGS]  = SCARAB_REG_ZPS;
+  reg_compress_map[(int)XED_REG_RIP]     = SCARAB_REG_RIP;
+
+  reg_compress_map[(int)XED_REG_DIL]  = SCARAB_REG_RDI;
+  reg_compress_map[(int)XED_REG_SIL]  = SCARAB_REG_RSI;
+  reg_compress_map[(int)XED_REG_BPL]  = SCARAB_REG_RBP;
+  reg_compress_map[(int)XED_REG_SPL]  = SCARAB_REG_RSP;
+  reg_compress_map[(int)XED_REG_R8B]  = SCARAB_REG_R8;
+  reg_compress_map[(int)XED_REG_R8W]  = SCARAB_REG_R8;
+  reg_compress_map[(int)XED_REG_R8D]  = SCARAB_REG_R8;
+  reg_compress_map[(int)XED_REG_R9B]  = SCARAB_REG_R9;
+  reg_compress_map[(int)XED_REG_R9W]  = SCARAB_REG_R9;
+  reg_compress_map[(int)XED_REG_R9D]  = SCARAB_REG_R9;
+  reg_compress_map[(int)XED_REG_R10B] = SCARAB_REG_R10;
+  reg_compress_map[(int)XED_REG_R10W] = SCARAB_REG_R10;
+  reg_compress_map[(int)XED_REG_R10D] = SCARAB_REG_R10;
+  reg_compress_map[(int)XED_REG_R11B] = SCARAB_REG_R11;
+  reg_compress_map[(int)XED_REG_R11W] = SCARAB_REG_R11;
+  reg_compress_map[(int)XED_REG_R11D] = SCARAB_REG_R11;
+  reg_compress_map[(int)XED_REG_R12B] = SCARAB_REG_R12;
+  reg_compress_map[(int)XED_REG_R12W] = SCARAB_REG_R12;
+  reg_compress_map[(int)XED_REG_R12D] = SCARAB_REG_R12;
+  reg_compress_map[(int)XED_REG_R13B] = SCARAB_REG_R13;
+  reg_compress_map[(int)XED_REG_R13W] = SCARAB_REG_R13;
+  reg_compress_map[(int)XED_REG_R13D] = SCARAB_REG_R13;
+  reg_compress_map[(int)XED_REG_R14B] = SCARAB_REG_R14;
+  reg_compress_map[(int)XED_REG_R14W] = SCARAB_REG_R14;
+  reg_compress_map[(int)XED_REG_R14D] = SCARAB_REG_R14;
+  reg_compress_map[(int)XED_REG_R15B] = SCARAB_REG_R15;
+  reg_compress_map[(int)XED_REG_R15W] = SCARAB_REG_R15;
+  reg_compress_map[(int)XED_REG_R15D] = SCARAB_REG_R15;
+
+  reg_compress_map[(int)XED_REG_XMM8]                  = SCARAB_REG_ZMM8;
+  reg_compress_map[(int)XED_REG_XMM9]                  = SCARAB_REG_ZMM9;
+  reg_compress_map[(int)XED_REG_XMM10]                 = SCARAB_REG_ZMM10;
+  reg_compress_map[(int)XED_REG_XMM11]                 = SCARAB_REG_ZMM11;
+  reg_compress_map[(int)XED_REG_XMM12]                 = SCARAB_REG_ZMM12;
+  reg_compress_map[(int)XED_REG_XMM13]                 = SCARAB_REG_ZMM13;
+  reg_compress_map[(int)XED_REG_XMM14]                 = SCARAB_REG_ZMM14;
+  reg_compress_map[(int)XED_REG_XMM15]                 = SCARAB_REG_ZMM15;
+  //reg_compress_map[(int)XED_REG_XMM_SSE_LAST]          = SCARAB_REG_ZMM15;
+  //reg_compress_map[(int)XED_REG_XMM_AVX_LAST]          = SCARAB_REG_ZMM15;
+  reg_compress_map[(int)XED_REG_XMM16]                 = SCARAB_REG_ZMM16;
+  //reg_compress_map[(int)XED_REG_XMM_AVX512_HI16_FIRST] = SCARAB_REG_ZMM16;
+  reg_compress_map[(int)XED_REG_XMM17]                 = SCARAB_REG_ZMM17;
+  reg_compress_map[(int)XED_REG_XMM18]                 = SCARAB_REG_ZMM18;
+  reg_compress_map[(int)XED_REG_XMM19]                 = SCARAB_REG_ZMM19;
+  reg_compress_map[(int)XED_REG_XMM20]                 = SCARAB_REG_ZMM20;
+  reg_compress_map[(int)XED_REG_XMM21]                 = SCARAB_REG_ZMM21;
+  reg_compress_map[(int)XED_REG_XMM22]                 = SCARAB_REG_ZMM22;
+  reg_compress_map[(int)XED_REG_XMM23]                 = SCARAB_REG_ZMM23;
+  reg_compress_map[(int)XED_REG_XMM24]                 = SCARAB_REG_ZMM24;
+  reg_compress_map[(int)XED_REG_XMM25]                 = SCARAB_REG_ZMM25;
+  reg_compress_map[(int)XED_REG_XMM26]                 = SCARAB_REG_ZMM26;
+  reg_compress_map[(int)XED_REG_XMM27]                 = SCARAB_REG_ZMM27;
+  reg_compress_map[(int)XED_REG_XMM28]                 = SCARAB_REG_ZMM28;
+  reg_compress_map[(int)XED_REG_XMM29]                 = SCARAB_REG_ZMM29;
+  reg_compress_map[(int)XED_REG_XMM30]                 = SCARAB_REG_ZMM30;
+  reg_compress_map[(int)XED_REG_XMM31]                 = SCARAB_REG_ZMM31;
+  //reg_compress_map[(int)XED_REG_XMM_AVX512_HI16_LAST]  = SCARAB_REG_ZMM31;
+  //reg_compress_map[(int)XED_REG_XMM_AVX512_LAST]       = SCARAB_REG_ZMM31;
+  reg_compress_map[(int)XED_REG_XMM_LAST]              = SCARAB_REG_ZMM31;
+
+  reg_compress_map[(int)XED_REG_YMM8]                  = SCARAB_REG_ZMM8;
+  reg_compress_map[(int)XED_REG_YMM9]                  = SCARAB_REG_ZMM9;
+  reg_compress_map[(int)XED_REG_YMM10]                 = SCARAB_REG_ZMM10;
+  reg_compress_map[(int)XED_REG_YMM11]                 = SCARAB_REG_ZMM11;
+  reg_compress_map[(int)XED_REG_YMM12]                 = SCARAB_REG_ZMM12;
+  reg_compress_map[(int)XED_REG_YMM13]                 = SCARAB_REG_ZMM13;
+  reg_compress_map[(int)XED_REG_YMM14]                 = SCARAB_REG_ZMM14;
+  reg_compress_map[(int)XED_REG_YMM15]                 = SCARAB_REG_ZMM15;
+  //reg_compress_map[(int)XED_REG_YMM_AVX_LAST]          = SCARAB_REG_ZMM15;
+  reg_compress_map[(int)XED_REG_YMM16]                 = SCARAB_REG_ZMM16;
+  //reg_compress_map[(int)XED_REG_YMM_AVX512_HI16_FIRST] = SCARAB_REG_ZMM16;
+  reg_compress_map[(int)XED_REG_YMM17]                 = SCARAB_REG_ZMM17;
+  reg_compress_map[(int)XED_REG_YMM18]                 = SCARAB_REG_ZMM18;
+  reg_compress_map[(int)XED_REG_YMM19]                 = SCARAB_REG_ZMM19;
+  reg_compress_map[(int)XED_REG_YMM20]                 = SCARAB_REG_ZMM20;
+  reg_compress_map[(int)XED_REG_YMM21]                 = SCARAB_REG_ZMM21;
+  reg_compress_map[(int)XED_REG_YMM22]                 = SCARAB_REG_ZMM22;
+  reg_compress_map[(int)XED_REG_YMM23]                 = SCARAB_REG_ZMM23;
+  reg_compress_map[(int)XED_REG_YMM24]                 = SCARAB_REG_ZMM24;
+  reg_compress_map[(int)XED_REG_YMM25]                 = SCARAB_REG_ZMM25;
+  reg_compress_map[(int)XED_REG_YMM26]                 = SCARAB_REG_ZMM26;
+  reg_compress_map[(int)XED_REG_YMM27]                 = SCARAB_REG_ZMM27;
+  reg_compress_map[(int)XED_REG_YMM28]                 = SCARAB_REG_ZMM28;
+  reg_compress_map[(int)XED_REG_YMM29]                 = SCARAB_REG_ZMM29;
+  reg_compress_map[(int)XED_REG_YMM30]                 = SCARAB_REG_ZMM30;
+  reg_compress_map[(int)XED_REG_YMM31]                 = SCARAB_REG_ZMM31;
+  //reg_compress_map[(int)XED_REG_YMM_AVX512_HI16_LAST]  = SCARAB_REG_ZMM31;
+  //reg_compress_map[(int)XED_REG_YMM_AVX512_LAST]       = SCARAB_REG_ZMM31;
+  reg_compress_map[(int)XED_REG_YMM_LAST]              = SCARAB_REG_ZMM31;
+
+  reg_compress_map[(int)XED_REG_ZMM8]                  = SCARAB_REG_ZMM8;
+  reg_compress_map[(int)XED_REG_ZMM9]                  = SCARAB_REG_ZMM9;
+  reg_compress_map[(int)XED_REG_ZMM10]                 = SCARAB_REG_ZMM10;
+  reg_compress_map[(int)XED_REG_ZMM11]                 = SCARAB_REG_ZMM11;
+  reg_compress_map[(int)XED_REG_ZMM12]                 = SCARAB_REG_ZMM12;
+  reg_compress_map[(int)XED_REG_ZMM13]                 = SCARAB_REG_ZMM13;
+  reg_compress_map[(int)XED_REG_ZMM14]                 = SCARAB_REG_ZMM14;
+  reg_compress_map[(int)XED_REG_ZMM15]                 = SCARAB_REG_ZMM15;
+  //reg_compress_map[(int)XED_REG_ZMM_AVX512_SPLIT_LAST] = SCARAB_REG_ZMM15;
+  reg_compress_map[(int)XED_REG_ZMM16]                 = SCARAB_REG_ZMM16;
+  //reg_compress_map[(int)XED_REG_ZMM_AVX512_HI16_FIRST] = SCARAB_REG_ZMM16;
+  reg_compress_map[(int)XED_REG_ZMM17]                 = SCARAB_REG_ZMM17;
+  reg_compress_map[(int)XED_REG_ZMM18]                 = SCARAB_REG_ZMM18;
+  reg_compress_map[(int)XED_REG_ZMM19]                 = SCARAB_REG_ZMM19;
+  reg_compress_map[(int)XED_REG_ZMM20]                 = SCARAB_REG_ZMM20;
+  reg_compress_map[(int)XED_REG_ZMM21]                 = SCARAB_REG_ZMM21;
+  reg_compress_map[(int)XED_REG_ZMM22]                 = SCARAB_REG_ZMM22;
+  reg_compress_map[(int)XED_REG_ZMM23]                 = SCARAB_REG_ZMM23;
+  reg_compress_map[(int)XED_REG_ZMM24]                 = SCARAB_REG_ZMM24;
+  reg_compress_map[(int)XED_REG_ZMM25]                 = SCARAB_REG_ZMM25;
+  reg_compress_map[(int)XED_REG_ZMM26]                 = SCARAB_REG_ZMM26;
+  reg_compress_map[(int)XED_REG_ZMM27]                 = SCARAB_REG_ZMM27;
+  reg_compress_map[(int)XED_REG_ZMM28]                 = SCARAB_REG_ZMM28;
+  reg_compress_map[(int)XED_REG_ZMM29]                 = SCARAB_REG_ZMM29;
+  reg_compress_map[(int)XED_REG_ZMM30]                 = SCARAB_REG_ZMM30;
+  reg_compress_map[(int)XED_REG_ZMM31]                 = SCARAB_REG_ZMM31;
+  //reg_compress_map[(int)XED_REG_ZMM_AVX512_HI16_LAST]  = SCARAB_REG_ZMM31;
+  //reg_compress_map[(int)XED_REG_ZMM_AVX512_LAST]       = SCARAB_REG_ZMM31;
+  reg_compress_map[(int)XED_REG_ZMM_LAST]              = SCARAB_REG_ZMM31;
+};
+
+void init_pin_opcode_convert(void) {
+  assert(OP_INV == 0);
+
+  iclass_to_scarab_map[XED_ICLASS_ADC]      = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ADCX]     = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ADC_LOCK] = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ADD]      = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ADDPD]    = {OP_FADD, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ADDPS]    = {OP_FADD, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ADDSD]    = {OP_FADD, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ADDSS]    = {OP_FADD, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ADDSUBPD] = {OP_FADD, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ADDSUBPS] = {OP_FADD, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ADD_LOCK] = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_AND]      = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ANDN]     = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ANDNPD]   = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ANDNPS]   = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ANDPD]    = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ANDPS]    = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_AND_LOCK] = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BLSI]     = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BLSMSK]   = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BLSR]     = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BSF] = {OP_NOTPIPELINED_MEDIUM, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BSR] = {OP_NOTPIPELINED_MEDIUM, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BSWAP]     = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BT]        = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BTC]       = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BTC_LOCK]  = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BTR]       = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BTR_LOCK]  = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BTS]       = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_BTS_LOCK]  = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CALL_FAR]  = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CALL_NEAR] = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CBW]       = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CDQ]       = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CDQE]      = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CLC]       = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CLD]       = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMC]       = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVB]     = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVBE]    = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVL]     = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVLE]    = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVNB]    = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVNBE]   = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVNL]    = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVNLE]   = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVNO]    = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVNP]    = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVNS]    = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVNZ]    = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVO]     = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVP]     = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVS]     = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMOVZ]     = {OP_CMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMP]       = {OP_ICMP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPPD]     = {OP_FCMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPPS]     = {OP_FCMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPSB]     = {OP_ICMP, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPSD]     = {OP_ICMP, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPSD_XMM] = {OP_FCMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPSQ]     = {OP_ICMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPSS]     = {OP_FCMP, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPSW]     = {OP_ICMP, 2, 1, NONE};
+  // TODO: make sure Scarab produces reasonable micro-ops for CMPXCHG.
+  // Also, should not be a Scarab ifetch barrier.
+  iclass_to_scarab_map[XED_ICLASS_CMPXCHG]         = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPXCHG16B]      = {OP_IADD, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPXCHG16B_LOCK] = {OP_IADD, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPXCHG8B]       = {OP_IADD, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPXCHG8B_LOCK]  = {OP_IADD, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CMPXCHG_LOCK]    = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_COMISD]          = {OP_ICMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_COMISS]          = {OP_ICMP, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTDQ2PD]        = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTDQ2PS]        = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTPD2DQ]        = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTPD2PI]        = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTPD2PS]        = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTPI2PD]        = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTPI2PS]        = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTPS2DQ]        = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTPS2PD]        = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTPS2PI]        = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTSD2SI]        = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTSD2SS]        = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTSI2SD]        = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTSI2SS]        = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTSS2SD]        = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTSS2SI]        = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTTPD2DQ]       = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTTPD2PI]       = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTTPS2DQ]       = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTTPS2PI]       = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTTSD2SI]       = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CVTTSS2SI]       = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CPUID]    = {OP_NOTPIPELINED_VERY_SLOW, -1, 1,
+                                            NONE};
+  iclass_to_scarab_map[XED_ICLASS_CQO]      = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CWD]      = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_CWDE]     = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_DEC]      = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_DEC_LOCK] = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_DIV]      = {OP_IDIV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_DIVPD]    = {OP_FDIV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_DIVPS]    = {OP_FDIV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_DIVSD]    = {OP_FDIV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_DIVSS]    = {OP_FDIV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FABS]     = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FADD]     = {OP_FADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FADDP]    = {OP_FADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCHS]     = {OP_LOGIC, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCMOVB]   = {OP_FCMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCMOVBE]  = {OP_FCMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCMOVE]   = {OP_FCMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCMOVNB]  = {OP_FCMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCMOVNBE] = {OP_FCMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCMOVNE]  = {OP_FCMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCMOVNU]  = {OP_FCMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCMOVU]   = {OP_FCMOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCOM]     = {OP_FCMP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCOMI]    = {OP_FCMP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCOMIP]   = {OP_FCMP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCOMP]    = {OP_FCMP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCOMPP]   = {OP_FCMP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FCOS]     = {OP_NOTPIPELINED_VERY_SLOW, 8, 1,
+                                           NONE};
+  iclass_to_scarab_map[XED_ICLASS_FDISI8087_NOP] = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FDIV]          = {OP_FDIV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FDIVP]         = {OP_FDIV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FDIVR]         = {OP_FDIV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FDIVRP]        = {OP_FDIV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FENI8087_NOP]  = {OP_NOP, -1, 1, NONE};
+  // Most FI* opcodes are mapped to FMUL to account for longer latency because
+  // they involve an integer/float convertion AND operate.
+  iclass_to_scarab_map[XED_ICLASS_FIADD]   = {OP_FMUL, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FICOM]   = {OP_FMUL, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FICOMP]  = {OP_FMUL, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FIDIV]   = {OP_FDIV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FIDIVR]  = {OP_FDIV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FILD]    = {OP_FCVT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FIMUL]   = {OP_FMUL, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FINCSTP] = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FIST]    = {OP_FCVT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FISTP]   = {OP_FCVT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FISTTP]  = {OP_FCVT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FISUB]   = {OP_FMUL, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FISUBR]  = {OP_FMUL, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FLD]     = {OP_MOV, -1, 1,
+                                          NONE};  // Potential FMOV
+  iclass_to_scarab_map[XED_ICLASS_FLD1]    = {OP_MOV, -1, 1,
+                                           NONE};  // Potential FMOV
+  iclass_to_scarab_map[XED_ICLASS_FLDCW]   = {OP_NOTPIPELINED_MEDIUM, -1, 1,
+                                            NONE};
+  iclass_to_scarab_map[XED_ICLASS_FLDL2E]  = {OP_MOV, -1, 1,
+                                             NONE};  // Potential FMOV
+  iclass_to_scarab_map[XED_ICLASS_FLDL2T]  = {OP_MOV, -1, 1,
+                                             NONE};  // Potential FMOV
+  iclass_to_scarab_map[XED_ICLASS_FLDLG2]  = {OP_MOV, -1, 1,
+                                             NONE};  // Potential FMOV
+  iclass_to_scarab_map[XED_ICLASS_FLDLN2]  = {OP_MOV, -1, 1,
+                                             NONE};  // Potential FMOV
+  iclass_to_scarab_map[XED_ICLASS_FLDPI]   = {OP_MOV, -1, 1,
+                                            NONE};  // Potential FMOV
+  iclass_to_scarab_map[XED_ICLASS_FLDZ]    = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FMUL]    = {OP_FMUL, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FMULP]   = {OP_FMUL, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FNCLEX] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FNSTCW] = {OP_NOTPIPELINED_MEDIUM, -1, 1,
+                                             NONE};
+  iclass_to_scarab_map[XED_ICLASS_FNSTSW] = {OP_NOTPIPELINED_MEDIUM, -1, 1,
+                                             NONE};
+  iclass_to_scarab_map[XED_ICLASS_FNOP]   = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FPREM]  = {OP_FMUL, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FRNDINT]       = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FSETPM287_NOP] = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FSIN]    = {OP_NOTPIPELINED_VERY_SLOW, 8, 1,
+                                           NONE};
+  iclass_to_scarab_map[XED_ICLASS_FSINCOS] = {OP_NOTPIPELINED_VERY_SLOW, 8, 1,
+                                              NONE};
+  iclass_to_scarab_map[XED_ICLASS_FSQRT]   = {OP_FDIV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FST]     = {OP_MOV, -1, 1,
+                                          NONE};  // Potential FMOV
+  iclass_to_scarab_map[XED_ICLASS_FSTP]    = {OP_MOV, -1, 1,
+                                           NONE};  // Potential FMOV
+  iclass_to_scarab_map[XED_ICLASS_FSUB]    = {OP_FADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FSUBP]   = {OP_FADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FSUBR]   = {OP_FADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FSUBRP]  = {OP_FADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FUCOM]   = {OP_FCMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FUCOMI]  = {OP_FCMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FUCOMIP] = {OP_FCMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FUCOMP]  = {OP_FCMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FUCOMPP] = {OP_FCMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FWAIT]   = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FXAM]    = {OP_FCMP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FXCH]    = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_FYL2X]   = {OP_NOTPIPELINED_VERY_SLOW, 8, 1,
+                                            NONE};
+  iclass_to_scarab_map[XED_ICLASS_FYL2XP1] = {OP_NOTPIPELINED_VERY_SLOW, 8, 1,
+                                              NONE};
+  iclass_to_scarab_map[XED_ICLASS_IDIV]    = {OP_IDIV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_IMUL]    = {OP_IMUL, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_INC]     = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_INT]     = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_INT3]    = {OP_IADD, -1, 1, NONE};
+  // TODO: find out what opcodes these iclasses correspond to.
+  // iclass_to_scarab_map[XED_ICLASS_INCPPSD] = {OP_IADD, -1, 1, NONE};
+  // iclass_to_scarab_map[XED_ICLASS_INCPPSQ] = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_INC_LOCK] = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JB]       = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JBE]      = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JCXZ]     = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JECXZ]    = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JL]       = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JLE]      = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JMP]      = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JMP_FAR]  = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JNB]      = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JNBE]     = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JNL]      = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JNLE]     = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JNO]      = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JNP]      = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JNS]      = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JNZ]      = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JO]       = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JP]       = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JRCXZ]    = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JS]       = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_JZ]       = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_KNOTB]    = {OP_LOGIC, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_KNOTD]    = {OP_LOGIC, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_KNOTQ]    = {OP_LOGIC, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_KNOTW]    = {OP_LOGIC, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_KMOVB]    = {OP_MOV, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_KMOVD]    = {OP_MOV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_KMOVQ]    = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_KMOVW]    = {OP_MOV, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_LDDQU]    = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_LDMXCSR]  = {OP_NOTPIPELINED_MEDIUM, -1, 1,
+                                              NONE};
+  iclass_to_scarab_map[XED_ICLASS_LEA]      = {OP_LDA, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_LEAVE]    = {OP_IADD, -1, 1, NONE};
+  // TODO: this should be a memory barrier if we want to support
+  // multi-threaded execution.
+  iclass_to_scarab_map[XED_ICLASS_LFENCE] = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_LODSB]  = {OP_MOV, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_LODSD]  = {OP_MOV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_LODSQ]  = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_LODSW]  = {OP_MOV, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_LSL]    = {OP_LDA, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_LZCNT]  = {OP_PIPELINED_FAST, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MAXPD]  = {OP_FCMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MAXPS]  = {OP_FCMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MAXSD]  = {OP_FCMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MAXSS]  = {OP_FCMP, 4, 1, NONE};
+  // TODO: this should be a memory barrier if we want to support
+  // multi-threaded execution.
+  iclass_to_scarab_map[XED_ICLASS_MFENCE]    = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MINPD]     = {OP_FCMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MINPS]     = {OP_FCMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MINSD]     = {OP_FCMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MINSS]     = {OP_FCMP, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOV]       = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVAPD]    = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVAPS]    = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVBE]     = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVD]      = {OP_PIPELINED_FAST, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVDDUP]   = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVDQ2Q]   = {OP_PIPELINED_FAST, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVDQA]    = {OP_MOV, 8, 2, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVDQU]    = {OP_MOV, 8, 2, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVHLPS]   = {OP_MOV, 4, 2, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVHPD]    = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVHPS]    = {OP_MOV, 4, 2, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVLHPS]   = {OP_MOV, 4, 2, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVLPD]    = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVLPS]    = {OP_MOV, 4, 2, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVMSKPD]  = {OP_PIPELINED_FAST, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVMSKPS]  = {OP_PIPELINED_FAST, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVNTDQ]   = {OP_MOV, 8, 2, NT};
+  iclass_to_scarab_map[XED_ICLASS_MOVNTDQA]  = {OP_MOV, 8, 2, NT};
+  iclass_to_scarab_map[XED_ICLASS_MOVNTI]    = {OP_MOV, -1, 1, NT};
+  iclass_to_scarab_map[XED_ICLASS_MOVNTPD]   = {OP_MOV, 8, -1, NT};
+  iclass_to_scarab_map[XED_ICLASS_MOVNTPS]   = {OP_MOV, 4, -1, NT};
+  iclass_to_scarab_map[XED_ICLASS_MOVNTQ]    = {OP_MOV, 8, 1, NT};
+  iclass_to_scarab_map[XED_ICLASS_MOVNTSD]   = {OP_MOV, 8, 1, NT};
+  iclass_to_scarab_map[XED_ICLASS_MOVNTSS]   = {OP_MOV, 4, 1, NT};
+  iclass_to_scarab_map[XED_ICLASS_MOVQ]      = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVQ2DQ]   = {OP_PIPELINED_FAST, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVSB]     = {OP_MOV, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVSD]     = {OP_MOV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVSD_XMM] = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVSHDUP]  = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVSLDUP]  = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVSQ]     = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVSS]     = {OP_MOV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVSW]     = {OP_MOV, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVSX]     = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVSXD]    = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVUPD]    = {OP_PIPELINED_FAST, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVUPS]    = {OP_PIPELINED_FAST, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MOVZX]     = {OP_MOV, -1, 1, NONE};
+  // Moves to debug and control registers, left unmapped
+  // iclass_to_scarab_map[XED_ICLASS_MOV_CR] = {OP_MOV, -1, 1, NONE};
+  // iclass_to_scarab_map[XED_ICLASS_MOV_DR] = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MPSADBW]   = {OP_NOTPIPELINED_MEDIUM, 1, 16,
+                                              NONE};
+  iclass_to_scarab_map[XED_ICLASS_MUL]       = {OP_IMUL, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MULPD]     = {OP_FMUL, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MULPS]     = {OP_FMUL, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MULSD]     = {OP_FMUL, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MULSS]     = {OP_FMUL, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_MULX]      = {OP_IMUL, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NEG]       = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NEG_LOCK]  = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NOP]       = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NOP2]      = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NOP3]      = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NOP4]      = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NOP5]      = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NOP6]      = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NOP7]      = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NOP8]      = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NOP9]      = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NOT]       = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_NOT_LOCK]  = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_OR]        = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ORPD]      = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ORPS]      = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_OR_LOCK]   = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PABSB]     = {OP_LOGIC, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PABSD]     = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PABSW]     = {OP_LOGIC, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PADDB]     = {OP_IADD, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PADDD]     = {OP_IADD, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PADDQ]     = {OP_IADD, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PADDSB]    = {OP_IADD, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PADDSW]    = {OP_IADD, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PADDUSB]   = {OP_IADD, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PADDUSW]   = {OP_IADD, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PADDW]     = {OP_IADD, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PALIGNR]   = {OP_SHIFT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PAND]      = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PANDN]     = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PAUSE]     = {OP_NOTPIPELINED_VERY_SLOW, 1, 1,
+                                            NONE};
+  iclass_to_scarab_map[XED_ICLASS_PAVGB]     = {OP_LOGIC, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PAVGW]     = {OP_LOGIC, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PBLENDVB]  = {OP_CMOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PBLENDW]   = {OP_CMOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PCMPEQB]   = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PCMPEQD]   = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PCMPEQQ]   = {OP_ICMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PCMPEQW]   = {OP_ICMP, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PCMPESTRI] = {OP_NOTPIPELINED_SLOW, 1, -1,
+                                                NONE};
+  iclass_to_scarab_map[XED_ICLASS_PCMPESTRM] = {OP_NOTPIPELINED_SLOW, 1, -1,
+                                                NONE};
+  iclass_to_scarab_map[XED_ICLASS_PCMPGTB]   = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PCMPGTD]   = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PCMPGTQ]   = {OP_ICMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PCMPGTW]   = {OP_ICMP, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PCMPISTRI] = {OP_NOTPIPELINED_SLOW, 1, -1,
+                                                NONE};
+  iclass_to_scarab_map[XED_ICLASS_PCMPISTRM] = {OP_NOTPIPELINED_SLOW, 1, -1,
+                                                NONE};
+  iclass_to_scarab_map[XED_ICLASS_PEXTRB]    = {OP_PIPELINED_FAST, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PEXTRD]    = {OP_PIPELINED_FAST, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PEXTRQ]    = {OP_PIPELINED_FAST, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PEXTRW]    = {OP_PIPELINED_FAST, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PEXTRW_SSE4] = {OP_PIPELINED_FAST, 2, 1,
+                                                  NONE};
+  iclass_to_scarab_map[XED_ICLASS_PINSRB]      = {OP_MOV, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PINSRD]      = {OP_MOV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PINSRQ]      = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PINSRW]      = {OP_MOV, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVMSKB]  = {OP_PIPELINED_FAST, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMADDUBSW] = {OP_IMUL, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMADDWD]   = {OP_IMUL, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMAXSB]    = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMAXSD]    = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMAXSW]    = {OP_ICMP, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMAXUB]    = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMAXUD]    = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMAXUW]    = {OP_ICMP, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMINSB]    = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMINSD]    = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMINSW]    = {OP_ICMP, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMINUB]    = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMINUD]    = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMINUW]    = {OP_ICMP, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVMSKB]  = {OP_PIPELINED_FAST, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVSXBD]  = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVSXBQ]  = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVSXBW]  = {OP_CMOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVSXDQ]  = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVSXWD]  = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVSXWQ]  = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVZXBD]  = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVZXBQ]  = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVZXBW]  = {OP_CMOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVZXDQ]  = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVZXWD]  = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMOVZXWQ]  = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMULDQ]    = {OP_IMUL, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMULHRSW]  = {OP_IMUL, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMULHRW]   = {OP_IMUL, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMULHUW]   = {OP_IMUL, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMULHW]    = {OP_IMUL, 2, -1, NONE};
+  // according to Agner Fog, PMULLD is twice the latency of the other PMUL*
+  // instructions...
+  iclass_to_scarab_map[XED_ICLASS_PMULLD]  = {OP_PIPELINED_MEDIUM, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMULLW]  = {OP_IMUL, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PMULUDQ] = {OP_IMUL, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_POP]     = {OP_IADD, -1, 1, NONE};
+  // POPA and POPAD should create multiple micro-ops
+  // iclass_to_scarab_map[XED_ICLASS_POPA] = {OP_IADD, -1, 1, NONE};
+  // iclass_to_scarab_map[XED_ICLASS_POPAD] = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_POPCNT] = {OP_PIPELINED_MEDIUM, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_POPF]   = {OP_NOTPIPELINED_SLOW, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_POPFD]  = {OP_NOTPIPELINED_SLOW, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_POPFQ]  = {OP_NOTPIPELINED_SLOW, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_POR]    = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PREFETCHNTA] = {OP_MOV, -1, 1, NT};
+  iclass_to_scarab_map[XED_ICLASS_PREFETCHT0]  = {OP_MOV, -1, 1, T0};
+  iclass_to_scarab_map[XED_ICLASS_PREFETCHT1]  = {OP_MOV, -1, 1, T1};
+  iclass_to_scarab_map[XED_ICLASS_PREFETCHT2]  = {OP_MOV, -1, 1, T2};
+  iclass_to_scarab_map[XED_ICLASS_PREFETCHW]   = {OP_MOV, -1, 1, W};
+  iclass_to_scarab_map[XED_ICLASS_PREFETCHWT1] = {OP_MOV, -1, 1, WT1};
+  // iclass_to_scarab_map[XED_ICLASS_PREFETCH_EXCLUSIVE] = {OP_MOV, -1, 1,
+  // EXCLUSIVE};
+  // iclass_to_scarab_map[XED_ICLASS_PREFETCH_RESERVED] = {OP_MOV, -1, 1,
+  // RESERVED};
+  iclass_to_scarab_map[XED_ICLASS_PSADBW]    = {OP_PIPELINED_FAST, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSHUFB]    = {OP_MOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSHUFD]    = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSHUFHW]   = {OP_MOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSHUFLW]   = {OP_MOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSHUFW]    = {OP_MOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSLLD]     = {OP_SHIFT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSLLDQ]    = {OP_SHIFT, 16, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSLLQ]     = {OP_SHIFT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSLLW]     = {OP_SHIFT, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSRAD]     = {OP_SHIFT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSRAW]     = {OP_SHIFT, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSRLD]     = {OP_SHIFT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSRLDQ]    = {OP_SHIFT, 16, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSRLQ]     = {OP_SHIFT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSRLW]     = {OP_SHIFT, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSUBB]     = {OP_IADD, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSUBD]     = {OP_IADD, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSUBQ]     = {OP_IADD, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSUBSB]    = {OP_IADD, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSUBSW]    = {OP_IADD, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSUBUSB]   = {OP_IADD, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSUBUSW]   = {OP_IADD, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PSUBW]     = {OP_IADD, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PTEST]     = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PUNPCKHBW] = {OP_MOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PUNPCKHDQ] = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PUNPCKHQDQ] = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PUNPCKHWD]  = {OP_MOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PUNPCKLBW]  = {OP_MOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PUNPCKLDQ]  = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PUNPCKLQDQ] = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PUNPCKLWD]  = {OP_MOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PUSH]       = {OP_IADD, -1, 1, NONE};
+  // PUSHA and PUSHAD should create multiple micro-ops
+  // iclass_to_scarab_map[XED_ICLASS_PUSHA] = {OP_IADD, -1, 1, NONE};
+  // iclass_to_scarab_map[XED_ICLASS_PUSHAD] = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PUSHF]  = {OP_NOTPIPELINED_SLOW, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PUSHFD] = {OP_NOTPIPELINED_SLOW, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PUSHFQ] = {OP_NOTPIPELINED_SLOW, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_PXOR]   = {OP_LOGIC, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_RDTSC]  = {OP_NOTPIPELINED_SLOW, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_RDTSCP]  = {OP_NOTPIPELINED_VERY_SLOW, -1, 1,
+					      NONE};
+  // INS_Opcode() never returns REPEAT variants of the iclasses
+  iclass_to_scarab_map[XED_ICLASS_REPE_CMPSB] = {OP_ICMP, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REPE_CMPSD] = {OP_ICMP, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REPE_CMPSQ] = {OP_ICMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REPE_CMPSW] = {OP_ICMP, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REPNE_CMPSB] = {OP_ICMP, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REPNE_CMPSD] = {OP_ICMP, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REPNE_CMPSQ] = {OP_ICMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REPNE_CMPSW] = {OP_ICMP, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REPNE_SCASB] = {OP_ICMP, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REPNE_SCASD] = {OP_ICMP, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REPNE_SCASQ] = {OP_ICMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REPNE_SCASW] = {OP_ICMP, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REP_MOVSB] = {OP_MOV, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REP_MOVSD] = {OP_MOV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REP_MOVSQ] = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REP_MOVSW] = {OP_MOV, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REP_STOSB] = {OP_MOV, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REP_STOSD] = {OP_MOV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REP_STOSQ] = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_REP_STOSW] = {OP_MOV, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_RET_FAR]  = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_RET_NEAR] = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ROL]      = {OP_SHIFT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ROR]      = {OP_SHIFT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_RORX]     = {OP_SHIFT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ROUNDPD]  = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ROUNDPS]  = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ROUNDSD]  = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_ROUNDSS]  = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_RSQRTPS] = {OP_PIPELINED_MEDIUM, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_RSQRTSS] = {OP_PIPELINED_MEDIUM, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SAHF]    = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SAR]     = {OP_SHIFT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SARX]    = {OP_SHIFT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SBB]     = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SBB_LOCK] = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SCASB]    = {OP_ICMP, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SCASD]    = {OP_ICMP, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SCASQ]    = {OP_ICMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SCASW]    = {OP_ICMP, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETB]     = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETBE]    = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETL]     = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETLE]    = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETNB]    = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETNBE]   = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETNL]    = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETNLE]   = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETNO]    = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETNP]    = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETNS]    = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETNZ]    = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETO]     = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETP]     = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETS]     = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SETZ]     = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SHL]      = {OP_SHIFT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SHLD]     = {OP_SHIFT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SHLX]     = {OP_SHIFT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SHR]      = {OP_SHIFT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SHRD]     = {OP_SHIFT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SHRX]     = {OP_SHIFT, -1, 1, NONE};
+  // TODO: this should be a memory barrier if we want to support
+  // multi-threaded execution.
+  iclass_to_scarab_map[XED_ICLASS_SFENCE]  = {OP_NOP, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SHUFPD]  = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SHUFPS]  = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SQRTPD]  = {OP_FDIV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SQRTPS]  = {OP_FDIV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SQRTSD]  = {OP_FDIV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SQRTSS]  = {OP_FDIV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_STMXCSR] = {OP_PIPELINED_MEDIUM, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_STOSB]   = {OP_MOV, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_STOSD]   = {OP_MOV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_STOSQ]   = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_STOSW]   = {OP_MOV, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SUB]     = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SUBPD]   = {OP_FADD, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SUBPS]   = {OP_FADD, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SUBSD]   = {OP_FADD, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SUBSS]   = {OP_FADD, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SUB_LOCK] = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SYSCALL]  = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_SYSENTER] = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_TEST]     = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_TZCNT]    = {OP_NOTPIPELINED_MEDIUM, -1, 1,
+                                            NONE};
+  iclass_to_scarab_map[XED_ICLASS_UCOMISD]  = {OP_FCMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_UCOMISS]  = {OP_FCMP, 4, -1, NONE};
+  // TODO: It works only for trace front-end now
+  iclass_to_scarab_map[XED_ICLASS_UD0]             = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_UD1]             = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_UD2]             = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_UNPCKHPD]        = {OP_MOV, -1, 8, NONE};
+  iclass_to_scarab_map[XED_ICLASS_UNPCKHPS]        = {OP_MOV, -1, 4, NONE};
+  iclass_to_scarab_map[XED_ICLASS_UNPCKLPD]        = {OP_MOV, -1, 8, NONE};
+  iclass_to_scarab_map[XED_ICLASS_UNPCKLPS]        = {OP_MOV, -1, 4, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VADDPD]          = {OP_FADD, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VADDPS]          = {OP_FADD, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VADDSD]          = {OP_FADD, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VADDSS]          = {OP_FADD, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VADDSUBPD]       = {OP_FADD, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VADDSUBPS]       = {OP_FADD, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VANDNPD]         = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VANDNPS]         = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VANDPD]          = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VANDPS]          = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBLENDMPD]       = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBLENDMPS]       = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBLENDPD]        = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBLENDPS]        = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBLENDVPD]       = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBLENDVPS]       = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTF128]  = {OP_MOV, 16, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTF32X2] = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTF32X4] = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTF32X8] = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTF64X2] = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTF64X4] = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTI128]  = {OP_MOV, 16, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTI32X2] = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTI32X4] = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTI32X8] = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTI64X2] = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTI64X4] = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTSD]    = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VBROADCASTSS]    = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCOMISD]         = {OP_ICMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCOMISS]         = {OP_ICMP, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCMPPD]          = {OP_FCMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCMPPS]          = {OP_FCMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCMPSD]          = {OP_FCMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCMPSS]          = {OP_FCMP, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTDQ2PD]       = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTDQ2PS]       = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTPD2DQ]       = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTPD2PS]       = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTPD2QQ]       = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTPD2UDQ]      = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTPD2UQQ]      = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTPH2PS]       = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTPS2DQ]       = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTPS2PD]       = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTPS2PH]       = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTPS2QQ]       = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTPS2UDQ]      = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTPS2UQQ]      = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTSD2SI]       = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTSD2SS]       = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTSD2USI]      = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTSI2SD]       = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTSI2SS]       = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTSS2SD]       = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTSS2SI]       = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTSS2USI]      = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTTPD2DQ]      = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTTPD2QQ]      = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTTPD2UDQ]     = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTTPD2UQQ]     = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTTPS2DQ]      = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTTPS2QQ]      = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTTPS2UDQ]     = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTTPS2UQQ]     = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTTSD2SI]      = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTTSD2USI]     = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTTSS2SI]      = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTTSS2USI]     = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTUDQ2PD]      = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTUDQ2PS]      = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTUQQ2PD]      = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTUQQ2PS]      = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTUSI2SD]      = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VCVTUSI2SS]      = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VDBPSADBW] = {OP_PIPELINED_FAST, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VDIVPD]    = {OP_FDIV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VDIVPS]    = {OP_FDIV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VDIVSD]    = {OP_FDIV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VDIVSS]    = {OP_FDIV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VEXTRACTF128]  = {OP_MOV, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VEXTRACTF32X4] = {OP_MOV, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VEXTRACTF32X8] = {OP_MOV, 32, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VEXTRACTF64X2] = {OP_MOV, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VEXTRACTF64X4] = {OP_MOV, 32, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VEXTRACTI128]  = {OP_MOV, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VEXTRACTI32X4] = {OP_MOV, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VEXTRACTI32X8] = {OP_MOV, 32, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VEXTRACTI64X2] = {OP_MOV, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VEXTRACTI64X4] = {OP_MOV, 32, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VEXTRACTPS]    = {OP_PIPELINED_FAST, 4, -1,
+                                                 NONE};
+  // FMA instructions
+  iclass_to_scarab_map[XED_ICLASS_VFMADD132PD]    = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADD132PS]    = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADD132SD]    = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADD132SS]    = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADD213PD]    = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADD213PS]    = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADD213SD]    = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADD213SS]    = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADD231PD]    = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADD231PS]    = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADD231SD]    = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADD231SS]    = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADDPD]       = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADDPS]       = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADDSD]       = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADDSS]       = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADDSUB132PD] = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADDSUB132PS] = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADDSUB213PD] = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADDSUB213PS] = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADDSUB231PD] = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADDSUB231PS] = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADDSUBPD]    = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMADDSUBPS]    = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUB132PD]    = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUB132PS]    = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUB132SD]    = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUB132SS]    = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUB213PD]    = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUB213PS]    = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUB213SD]    = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUB213SS]    = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUB231PD]    = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUB231PS]    = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUB231SD]    = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUB231SS]    = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUBADD132PD] = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUBADD132PS] = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUBADD213PD] = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUBADD213PS] = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUBADD231PD] = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUBADD231PS] = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUBADDPD]    = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUBADDPS]    = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUBPD]       = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUBPS]       = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUBSD]       = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFMSUBSS]       = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADD132PD]   = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADD132PS]   = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADD132SD]   = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADD132SS]   = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADD213PD]   = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADD213PS]   = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADD213SD]   = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADD213SS]   = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADD231PD]   = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADD231PS]   = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADD231SD]   = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADD231SS]   = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADDPD]      = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADDPS]      = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADDSD]      = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMADDSS]      = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUB132PD]   = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUB132PS]   = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUB132SD]   = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUB132SS]   = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUB213PD]   = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUB213PS]   = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUB213SD]   = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUB213SS]   = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUB231PD]   = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUB231PS]   = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUB231SD]   = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUB231SS]   = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUBPD]      = {OP_FMA, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUBPS]      = {OP_FMA, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUBSD]      = {OP_FMA, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VFNMSUBSS]      = {OP_FMA, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VGATHERDPD]     = {OP_GATHER, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VGATHERDPS]     = {OP_GATHER, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VGATHERPF0DPD]  = {OP_GATHER, 4, 16, T0};
+  iclass_to_scarab_map[XED_ICLASS_VGATHERPF0DPS]  = {OP_GATHER, 4, 16, T0};
+  iclass_to_scarab_map[XED_ICLASS_VGATHERPF0QPD]  = {OP_GATHER, 8, 8, T0};
+  iclass_to_scarab_map[XED_ICLASS_VGATHERPF0QPS]  = {OP_GATHER, 8, 8, T0};
+  iclass_to_scarab_map[XED_ICLASS_VGATHERPF1DPD]  = {OP_GATHER, 4, 16, T1};
+  iclass_to_scarab_map[XED_ICLASS_VGATHERPF1DPS]  = {OP_GATHER, 4, 16, T1};
+  iclass_to_scarab_map[XED_ICLASS_VGATHERPF1QPD]  = {OP_GATHER, 8, 8, T1};
+  iclass_to_scarab_map[XED_ICLASS_VGATHERPF1QPS]  = {OP_GATHER, 8, 8, T1};
+  iclass_to_scarab_map[XED_ICLASS_VGATHERQPD]     = {OP_GATHER, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VGATHERQPS]     = {OP_GATHER, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VGETEXPPD]      = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VGETEXPPS]      = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VGETEXPSD]      = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VGETEXPSS]      = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VGETMANTPD]     = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VGETMANTPS]     = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VGETMANTSD]     = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VGETMANTSS]     = {OP_FCVT, 4, 1, NONE};
+
+  iclass_to_scarab_map[XED_ICLASS_VINSERTF128]  = {OP_MOV, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VINSERTF32X4] = {OP_MOV, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VINSERTF32X8] = {OP_MOV, 32, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VINSERTF64X2] = {OP_MOV, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VINSERTF64X4] = {OP_MOV, 32, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VINSERTI128]  = {OP_MOV, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VINSERTI32X4] = {OP_MOV, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VINSERTI32X8] = {OP_MOV, 32, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VINSERTI64X2] = {OP_MOV, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VINSERTI64X4] = {OP_MOV, 32, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VINSERTPS]    = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VLDMXCSR]    = {OP_NOTPIPELINED_MEDIUM, -1, 1,
+                                               NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMASKMOVDQU] = {OP_PIPELINED_FAST, 1, -1,
+                                                  NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMASKMOVPD]  = {OP_PIPELINED_FAST, 8, -1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMASKMOVPS]  = {OP_PIPELINED_FAST, 4, -1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMAXPD]      = {OP_FCMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMAXPS]      = {OP_FCMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMAXSD]      = {OP_FCMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMAXSS]      = {OP_FCMP, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMINPD]      = {OP_FCMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMINPS]      = {OP_FCMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMINSD]      = {OP_FCMP, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMINSS]      = {OP_FCMP, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVAPD]     = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVAPS]     = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVD]       = {OP_MOV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVDDUP]    = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVDDUP]    = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVDQA]     = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVDQA32]   = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVDQA64]   = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVDQU]     = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVDQU16]   = {OP_MOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVDQU32]   = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVDQU64]   = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVDQU8]    = {OP_MOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVHLPS]    = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVHPD]     = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVHPS]     = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVLHPS]    = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVLPD]     = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVLPS]     = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVMSKPD] = {OP_PIPELINED_FAST, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVMSKPS] = {OP_PIPELINED_FAST, -1, 1, NONE};
+  // TODO: Scarab currently does not support stores with non-temporal hints.
+  // It will simply produces a store micro-op that does not bypass the cache.
+  // Should we model this as a simple OP_NOTPIPELINED_VERY_SLOW?
+  iclass_to_scarab_map[XED_ICLASS_VMOVNTDQ]  = {OP_MOV, -1, 1, NT};
+  iclass_to_scarab_map[XED_ICLASS_VMOVNTDQA] = {OP_MOV, -1, 1, NT};
+  iclass_to_scarab_map[XED_ICLASS_VMOVNTPD]  = {OP_MOV, 8, -1, NT};
+  iclass_to_scarab_map[XED_ICLASS_VMOVNTPS]  = {OP_MOV, 4, -1, NT};
+  iclass_to_scarab_map[XED_ICLASS_VMOVQ]     = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVSD]    = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVSHDUP] = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVSLDUP] = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVSS]    = {OP_MOV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVUPD]   = {OP_PIPELINED_FAST, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMOVUPS]   = {OP_PIPELINED_FAST, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMPSADBW]  = {OP_NOTPIPELINED_MEDIUM, 1, -1,
+                                               NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMULPD]    = {OP_FMUL, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMULPS]    = {OP_FMUL, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMULSD]    = {OP_FMUL, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VMULSS]    = {OP_FMUL, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VORPD]     = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VORPS]     = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPABSB]    = {OP_LOGIC, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPABSD]    = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPABSQ]    = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPABSW]    = {OP_LOGIC, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPACKSSDW] = {OP_MOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPACKSSWB] = {OP_MOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPACKUSDW] = {OP_MOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPACKUSWB] = {OP_MOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPADDB]    = {OP_IADD, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPADDD]    = {OP_IADD, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPADDQ]    = {OP_IADD, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPADDSB]   = {OP_IADD, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPADDSW]   = {OP_IADD, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPADDUSB]  = {OP_IADD, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPADDUSW]  = {OP_IADD, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPADDW]    = {OP_IADD, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPALIGNR]  = {OP_SHIFT, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPAND]     = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPANDD]    = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPANDN]    = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPANDND]   = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPANDNQ]   = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPANDQ]    = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPAVGB]    = {OP_LOGIC, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPAVGW]    = {OP_LOGIC, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBLENDD]  = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBLENDMB] = {OP_CMOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBLENDMD] = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBLENDMQ] = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBLENDMW] = {OP_CMOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBLENDVB] = {OP_CMOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBLENDW]  = {OP_CMOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBROADCASTB]    = {OP_MOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBROADCASTD]    = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBROADCASTMB2Q] = {OP_PIPELINED_MEDIUM, 8,
+                                                      -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBROADCASTMW2D] = {OP_PIPELINED_MEDIUM, 4,
+                                                      -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBROADCASTQ]    = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPBROADCASTW]    = {OP_MOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPB]          = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPD]          = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPEQB]        = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPEQD]        = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPEQQ]        = {OP_ICMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPEQW]        = {OP_ICMP, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPESTRI] = {OP_NOTPIPELINED_SLOW, 1, -1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPESTRM] = {OP_NOTPIPELINED_SLOW, 1, -1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPGTB]   = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPGTD]   = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPGTQ]   = {OP_ICMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPGTW]   = {OP_ICMP, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPISTRI] = {OP_NOTPIPELINED_SLOW, 1, -1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPCMPISTRM] = {OP_NOTPIPELINED_SLOW, 1, -1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPERM2F128] = {OP_MOV, 16, 1,
+                                                 NONE};  // TODO: Move or shift?
+  iclass_to_scarab_map[XED_ICLASS_VPERM2I128] = {OP_MOV, 16, 1,
+                                                 NONE};  // TODO: Move or shift?
+  iclass_to_scarab_map[XED_ICLASS_VPERMB]     = {OP_MOV, 1, -1,
+                                             NONE};  // TODO: Move or shift?
+  iclass_to_scarab_map[XED_ICLASS_VPERMD]     = {OP_MOV, 4, -1,
+                                             NONE};  // TODO: Move or shift?
+  iclass_to_scarab_map[XED_ICLASS_VPERMQ]     = {OP_MOV, 8, -1,
+                                             NONE};  // TODO: Move or shift?
+  iclass_to_scarab_map[XED_ICLASS_VPERMT2B]  = {OP_PIPELINED_FAST, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPERMT2D]  = {OP_PIPELINED_FAST, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPERMT2PD] = {OP_PIPELINED_FAST, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPERMT2PS] = {OP_PIPELINED_FAST, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPERMT2Q]  = {OP_PIPELINED_FAST, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPERMT2W]  = {OP_PIPELINED_FAST, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPERMW]    = {OP_MOV, 2, -1,
+                                             NONE};  // TODO: Move or shift?
+  iclass_to_scarab_map[XED_ICLASS_VPERMPD]   = {OP_PIPELINED_FAST, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPERMPS]   = {OP_PIPELINED_FAST, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPERMI2W]  = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPEXTRB]   = {OP_PIPELINED_FAST, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPEXTRD]   = {OP_PIPELINED_FAST, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPEXTRQ]   = {OP_PIPELINED_FAST, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPEXTRW]   = {OP_PIPELINED_FAST, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPGATHERDD] = {OP_GATHER, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPGATHERDQ] = {OP_GATHER, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPGATHERQD] = {OP_GATHER, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPGATHERQQ] = {OP_GATHER, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPINSRB]    = {OP_MOV, 1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPINSRD]    = {OP_MOV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPINSRQ]    = {OP_MOV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPINSRW]    = {OP_MOV, 2, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMADDUBSW] = {OP_IMUL, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMADDWD]   = {OP_IMUL, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMASKMOVD] = {OP_PIPELINED_MEDIUM, 4, -1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMASKMOVQ] = {OP_PIPELINED_MEDIUM, 8, -1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMAXSB]    = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMAXSD]    = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMAXSQ]    = {OP_ICMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMAXSW]    = {OP_ICMP, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMAXUB]    = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMAXUD]    = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMAXUQ]    = {OP_ICMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMAXUW]    = {OP_ICMP, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMINSB]    = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMINSD]    = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMINSQ]    = {OP_ICMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMINSW]    = {OP_ICMP, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMINUB]    = {OP_ICMP, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMINUD]    = {OP_ICMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMINUQ]    = {OP_ICMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMINUW]    = {OP_ICMP, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVB2M]  = {OP_PIPELINED_FAST, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVD2M]  = {OP_PIPELINED_FAST, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVDB]   = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVDW]   = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVM2B]  = {OP_PIPELINED_FAST, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVM2D]  = {OP_PIPELINED_FAST, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVM2Q]  = {OP_PIPELINED_FAST, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVM2W]  = {OP_PIPELINED_FAST, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVMSKB] = {OP_PIPELINED_FAST, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVQ2M]  = {OP_PIPELINED_FAST, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVQB]   = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVQD]   = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVQW]   = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVSDB]  = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVSDW]  = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVSQB]  = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVSQD]  = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVSQW]  = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVSWB]  = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVSXBD] = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVSXBQ] = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVSXBW] = {OP_CMOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVSXDQ] = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVSXWD] = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVSXWQ] = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVUSDB] = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVUSDW] = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVUSQB] = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVUSQD] = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVUSQW] = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVUSWB] = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVW2M]  = {OP_PIPELINED_FAST, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVWB]   = {OP_CMOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVZXBD] = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVZXBQ] = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVZXBW] = {OP_CMOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVZXDQ] = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVZXWD] = {OP_CMOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMOVZXWQ] = {OP_CMOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMULDQ]   = {OP_IMUL, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMULHRSW] = {OP_IMUL, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMULHUW]  = {OP_IMUL, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMULHW]   = {OP_IMUL, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMULLD] = {OP_PIPELINED_MEDIUM, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMULLQ] = {OP_PIPELINED_SLOW, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPMULLW] = {OP_IMUL, 2, -1, NONE};
+  // each destination lane of VPMULUDQ is 8 bytes, even though each source lane
+  // is only 4 bytes.
+  iclass_to_scarab_map[XED_ICLASS_VPMULUDQ] = {OP_IMUL, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPOR]     = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPORD]    = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPORQ]    = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSADBW]  = {OP_PIPELINED_FAST, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSCATTERDD] = {OP_SCATTER, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSCATTERDQ] = {OP_SCATTER, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSCATTERQD] = {OP_SCATTER, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSCATTERQQ] = {OP_SCATTER, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSHUFB]     = {OP_MOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSHUFD]     = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSHUFHW]    = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSHUFLW]    = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSLLD]      = {OP_SHIFT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSLLDQ]     = {OP_SHIFT, 16, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSLLQ]      = {OP_SHIFT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSLLVD]     = {OP_SHIFT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSLLVQ]     = {OP_SHIFT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSLLVW]     = {OP_SHIFT, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSLLW]      = {OP_SHIFT, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRAD]      = {OP_SHIFT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRAQ]      = {OP_SHIFT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRAVD]     = {OP_SHIFT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRAVQ]     = {OP_SHIFT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRAVW]     = {OP_SHIFT, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRAW]      = {OP_SHIFT, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRLD]      = {OP_SHIFT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRLDQ]     = {OP_SHIFT, 16, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRLQ]      = {OP_SHIFT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRLVD]     = {OP_SHIFT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRLVQ]     = {OP_SHIFT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRLVW]     = {OP_SHIFT, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSRLW]      = {OP_SHIFT, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSUBB]      = {OP_IADD, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSUBD]      = {OP_IADD, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSUBQ]      = {OP_IADD, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSUBSB]     = {OP_IADD, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSUBSW]     = {OP_IADD, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSUBUSB]    = {OP_IADD, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSUBUSW]    = {OP_IADD, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPSUBW]      = {OP_IADD, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPTERNLOGD]  = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPTERNLOGQ]  = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPTEST]      = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPUNPCKHBW]  = {OP_MOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPUNPCKHDQ]  = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPUNPCKHQDQ] = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPUNPCKHWD]  = {OP_MOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPUNPCKLBW]  = {OP_MOV, 1, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPUNPCKLDQ]  = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPUNPCKLQDQ] = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPUNPCKLWD]  = {OP_MOV, 2, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPXOR]       = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPXORD]      = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VPXORQ]      = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRCP14PD]    = {OP_NOTPIPELINED_MEDIUM, 8, -1,
+                                               NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRCP14PS]    = {OP_NOTPIPELINED_MEDIUM, 4, -1,
+                                               NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRCP14SD]    = {OP_NOTPIPELINED_MEDIUM, 8, 1,
+                                               NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRCP14SS]    = {OP_NOTPIPELINED_MEDIUM, 4, 1,
+                                               NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRCP28PD]    = {OP_NOTPIPELINED_MEDIUM, 8, -1,
+                                               NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRCP28PS]    = {OP_NOTPIPELINED_MEDIUM, 4, -1,
+                                               NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRCP28SD]    = {OP_NOTPIPELINED_MEDIUM, 8, 1,
+                                               NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRCP28SS]    = {OP_NOTPIPELINED_MEDIUM, 4, 1,
+                                               NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRCPPS]      = {OP_NOTPIPELINED_MEDIUM, 4, -1,
+                                             NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRCPSS]      = {OP_NOTPIPELINED_MEDIUM, 4, 1,
+                                             NONE};
+  iclass_to_scarab_map[XED_ICLASS_VREDUCEPD]   = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VREDUCEPS]   = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VREDUCESD]   = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VREDUCESS]   = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRNDSCALEPD] = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRNDSCALEPS] = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRNDSCALESD] = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRNDSCALESS] = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VROUNDPD]    = {OP_FCVT, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VROUNDPS]    = {OP_FCVT, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VROUNDSD]    = {OP_FCVT, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VROUNDSS]    = {OP_FCVT, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRSQRT14PD]  = {OP_PIPELINED_MEDIUM, 8, -1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRSQRT14PS]  = {OP_PIPELINED_MEDIUM, 4, -1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRSQRT14SD]  = {OP_PIPELINED_MEDIUM, 8, 1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRSQRT14SS]  = {OP_PIPELINED_MEDIUM, 4, 1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRSQRT28PD]  = {OP_PIPELINED_MEDIUM, 8, -1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRSQRT28PS]  = {OP_PIPELINED_MEDIUM, 4, -1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRSQRT28SD]  = {OP_PIPELINED_MEDIUM, 8, 1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRSQRT28SS]  = {OP_PIPELINED_MEDIUM, 4, 1,
+                                                 NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRSQRTPS]    = {OP_PIPELINED_MEDIUM, 4, -1,
+                                               NONE};
+  iclass_to_scarab_map[XED_ICLASS_VRSQRTSS] = {OP_PIPELINED_MEDIUM, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSCATTERDPD]    = {OP_SCATTER, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSCATTERDPS]    = {OP_SCATTER, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF0DPD] = {OP_SCATTER, 4, 16, T0};
+  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF0DPS] = {OP_SCATTER, 4, 16, T0};
+  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF0QPD] = {OP_SCATTER, 8, 8, T0};
+  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF0QPS] = {OP_SCATTER, 8, 8, T0};
+  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF1DPD] = {OP_SCATTER, 4, 16, T1};
+  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF1DPS] = {OP_SCATTER, 4, 16, T1};
+  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF1QPD] = {OP_SCATTER, 8, 8, T1};
+  iclass_to_scarab_map[XED_ICLASS_VSCATTERPF1QPS] = {OP_SCATTER, 8, 8, T1};
+  iclass_to_scarab_map[XED_ICLASS_VSCATTERQPD]    = {OP_SCATTER, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSCATTERQPS]    = {OP_SCATTER, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSHUFPD]        = {OP_MOV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSHUFPS]        = {OP_MOV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSQRTPD]        = {OP_FDIV, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSQRTPS]        = {OP_FDIV, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSQRTSD]        = {OP_FDIV, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSQRTSS]        = {OP_FDIV, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSTMXCSR]   = {OP_NOTPIPELINED_MEDIUM, -1, 1,
+                                               NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSUBPD]     = {OP_FADD, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSUBPS]     = {OP_FADD, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSUBSD]     = {OP_FADD, 8, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VSUBSS]     = {OP_FADD, 4, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VUCOMISD]   = {OP_FCMP, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VUCOMISS]   = {OP_FCMP, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VUNPCKHPD]  = {OP_MOV, -1, 8, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VUNPCKHPS]  = {OP_MOV, -1, 4, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VUNPCKLPD]  = {OP_MOV, -1, 8, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VUNPCKLPS]  = {OP_MOV, -1, 4, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VXORPD]     = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VXORPS]     = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VZEROALL]   = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_VZEROUPPER] = {OP_LOGIC, 16, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_XADD]       = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_XADD_LOCK]  = {OP_IADD, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_XCHG]       = {OP_MOV, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_XGETBV] = {OP_NOTPIPELINED_SLOW, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_XOR]    = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_XORPD]  = {OP_LOGIC, 8, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_XORPS]  = {OP_LOGIC, 4, -1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_XOR_LOCK] = {OP_LOGIC, -1, 1, NONE};
+  iclass_to_scarab_map[XED_ICLASS_XRSTOR]   = {OP_NOTPIPELINED_VERY_SLOW, -1, 1,
+                                             NONE};
+  iclass_to_scarab_map[XED_ICLASS_XSAVE]    = {OP_NOTPIPELINED_VERY_SLOW, -1, 1,
+                                            NONE};
+  iclass_to_scarab_map[XED_ICLASS_XSAVEC]   = {OP_NOTPIPELINED_VERY_SLOW, -1, 1,
+                                             NONE};
+}

--- a/src/pin/pin_lib/x86_decoder.h
+++ b/src/pin/pin_lib/x86_decoder.h
@@ -24,31 +24,33 @@
 
 #include "assert.h"
 
-#include "pin_api_to_xed.h"
-#include "x87_stack_delta.h"
-#include "pin_scarab_common_lib.h"
 #include "../../ctype_pin_inst.h"
 #include "../../table_info.h"
+#include "pin_api_to_xed.h"
+#include "pin_scarab_common_lib.h"
+#include "x87_stack_delta.h"
 
-#include <unordered_map>
 #include <ostream>
+#include <unordered_map>
 
 // Global static instructions map
 typedef std::unordered_map<ADDRINT, ctype_pin_inst*> inst_info_map;
-typedef inst_info_map::iterator                 inst_info_map_p;
+typedef inst_info_map::iterator                      inst_info_map_p;
 
 /**************************** Public Functions ********************************/
 
-void     init_x86_decoder(std::ostream* err_ostream);
-void     fill_in_basic_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins);
-uint32_t add_dependency_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins);
+void init_x86_decoder(std::ostream* err_ostream);
+void fill_in_basic_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins);
+uint32_t add_dependency_info(ctype_pin_inst*           info,
+                             const xed_decoded_inst_t* ins);
 void     fill_in_simd_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins,
                            uint32_t max_op_width);
-void     apply_x87_bug_workaround(ctype_pin_inst* info, const xed_decoded_inst_t* ins);
+void     apply_x87_bug_workaround(ctype_pin_inst*           info,
+                                  const xed_decoded_inst_t* ins);
 void     fill_in_cf_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins);
 
-void     print_err_if_invalid(ctype_pin_inst* info, const xed_decoded_inst_t* ins);
+void print_err_if_invalid(ctype_pin_inst* info, const xed_decoded_inst_t* ins);
 
-uint8_t  is_ifetch_barrier(const xed_decoded_inst_t* ins);
+uint8_t is_ifetch_barrier(const xed_decoded_inst_t* ins);
 
-#endif //__X86_DECODER_H__
+#endif  //__X86_DECODER_H__

--- a/src/pin/pin_lib/x86_decoder.h
+++ b/src/pin/pin_lib/x86_decoder.h
@@ -19,37 +19,36 @@
  * SOFTWARE.
  */
 
-#ifndef __DECODER_H__
-#define __DECODER_H__
+#ifndef __X86_DECODER_H__
+#define __X86_DECODER_H__
 
-#undef UNUSED   // there is a name conflict between PIN and Scarab
-#undef WARNING  // there is a name conflict between PIN and Scarab
+#include "assert.h"
 
-#include "pin.H"
-
-#undef UNUSED   // there is a name conflict between PIN and Scarab
-#undef WARNING  // there is a name conflict between PIN and Scarab
+#include "pin_api_to_xed.h"
+#include "x87_stack_delta.h"
+#include "pin_scarab_common_lib.h"
 #include "../../ctype_pin_inst.h"
 #include "../../table_info.h"
-#include "x86_decoder.h"
+
+#include <unordered_map>
 #include <ostream>
 
-using namespace std;
+// Global static instructions map
+typedef std::unordered_map<ADDRINT, ctype_pin_inst*> inst_info_map;
+typedef inst_info_map::iterator                 inst_info_map_p;
 
-void pin_decoder_init(bool translate_x87_regs, std::ostream* err_ostream);
+/**************************** Public Functions ********************************/
 
-void pin_decoder_insert_analysis_functions(const INS& ins);
-void     insert_analysis_functions(ctype_pin_inst* info, const INS& ins);
-ctype_pin_inst* pin_decoder_get_latest_inst();
+void     init_x86_decoder(std::ostream* err_ostream);
+void     fill_in_basic_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins);
+uint32_t add_dependency_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins);
+void     fill_in_simd_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins,
+                           uint32_t max_op_width);
+void     apply_x87_bug_workaround(ctype_pin_inst* info, const xed_decoded_inst_t* ins);
+void     fill_in_cf_info(ctype_pin_inst* info, const xed_decoded_inst_t* ins);
 
-void pin_decoder_print_unknown_opcodes();
+void     print_err_if_invalid(ctype_pin_inst* info, const xed_decoded_inst_t* ins);
 
-vector<PIN_MEM_ACCESS_INFO>
-  get_gather_scatter_mem_access_infos_from_gather_scatter_info(
-    const CONTEXT* ctxt, const PIN_MULTI_MEM_ACCESS_INFO* infos_from_pin);
+uint8_t  is_ifetch_barrier(const xed_decoded_inst_t* ins);
 
-ctype_pin_inst create_sentinel();
-ctype_pin_inst create_dummy_jump(uint64_t eip, uint64_t tgt);
-ctype_pin_inst create_dummy_nop(uint64_t eip, Wrongpath_Nop_Mode_Reason reason);
-
-#endif  // __DECODER_H__
+#endif //__X86_DECODER_H__

--- a/src/pin/pin_lib/x87_stack_delta.cc
+++ b/src/pin/pin_lib/x87_stack_delta.cc
@@ -19,23 +19,19 @@
  * SOFTWARE.
  */
 
-#include "x87_stack_delta.h"
+#include "pin/pin_lib/x87_stack_delta.h"
 #include <iostream>
-#include "decoder.h"
-
-#undef UNUSED   // there is a name conflict between PIN and Scarab
-#undef WARNING  // there is a name conflict between PIN and Scarab
-#include "pin.H"
-#undef UNUSED   // there is a name conflict between PIN and Scarab
-#undef WARNING  // there is a name conflict between PIN and Scarab
 
 #define REG(x) SCARAB_REG_##x,
 typedef enum Reg_Id_struct {
-#include "../../isa/x86_regs.def"
+#include "isa/x86_regs.def"
   SCARAB_NUM_REGS
 } Reg_Id;
 #undef REG
 
+#include "pin/pin_lib/x86_decoder.h"
+
+#define ASSERTX assert
 
 /* x87 stack deltas for floating point opcodes */
 static struct {
@@ -187,8 +183,9 @@ void update_x87_stack_state(int opcode) {
 
 void init_x87_stack_delta() {
   for(size_t opcode = XED_ICLASS_INVALID; opcode < XED_ICLASS_LAST; ++opcode) {
-    opcode_to_delta_map[opcode]   = 0;
-    const std::string opcode_name = OPCODE_StringShort(opcode);
+    opcode_to_delta_map[opcode] = 0;
+    xed_iclass_enum_t iclass = static_cast<xed_iclass_enum_t>(opcode);
+    const std::string opcode_name(xed_iclass_enum_t2str(iclass));
     size_t            i;
     for(i = 0; opcode_infos[i].name; ++i) {
       if(opcode_name == std::string(opcode_infos[i].name)) {
@@ -197,8 +194,8 @@ void init_x87_stack_delta() {
       }
     }
     if(!opcode_infos[i].name && opcode_name.c_str()[0] == 'F') {
-      std::clog << "Possible unmatched x87 opcode: " << opcode_name
-                << std::endl;
+      //      std::clog << "Possible unmatched x87 opcode: " << opcode_name
+      //        << std::endl;
     }
   }
 }

--- a/src/pin/pin_lib/x87_stack_delta.cc
+++ b/src/pin/pin_lib/x87_stack_delta.cc
@@ -184,7 +184,7 @@ void update_x87_stack_state(int opcode) {
 void init_x87_stack_delta() {
   for(size_t opcode = XED_ICLASS_INVALID; opcode < XED_ICLASS_LAST; ++opcode) {
     opcode_to_delta_map[opcode] = 0;
-    xed_iclass_enum_t iclass = static_cast<xed_iclass_enum_t>(opcode);
+    xed_iclass_enum_t iclass    = static_cast<xed_iclass_enum_t>(opcode);
     const std::string opcode_name(xed_iclass_enum_t2str(iclass));
     size_t            i;
     for(i = 0; opcode_infos[i].name; ++i) {

--- a/utils/diff_scarab_ops.py
+++ b/utils/diff_scarab_ops.py
@@ -17,20 +17,23 @@ def parse_args():
   parser.add_argument('file2_path', help='Path to the second Scarab standard output file')
   return parser.parse_args()
 
-def read_file(path):
-  with open(path) as f:
-    return [(i, line.strip()) for i, line in enumerate(f) if line.strip().startswith('DEBUG_OP_FIELDS')]
+class LogReader:
+  def __init__(self, path):
+    self.path = path
+
+  def __iter__(self):
+    with open(self.path) as f:
+      for i, line in enumerate(f):
+        if not line.strip().startswith('DEBUG_OP_FIELDS'): continue
+        yield i, line.strip()
 
 def main():
   args = parse_args()
 
-  file1_lines = read_file(args.file1_path)
-  file2_lines = read_file(args.file2_path)
-
   histogram = defaultdict(lambda: defaultdict(lambda: 0))
   bucket_contents = defaultdict(lambda: defaultdict(lambda: []))
 
-  for (line1_number, line1), (line2_number, line2) in zip(file1_lines, file2_lines):
+  for (line1_number, line1), (line2_number, line2) in zip(LogReader(args.file1_path), LogReader(args.file2_path)):
     if line1 != line2:
       words = line1.split()
       assert words[0] == 'DEBUG_OP_FIELDS'


### PR DESCRIPTION
Split the decoder into decoder/x86_decoder where x86_decoder
performs static decoding of instructions and decoder performs
extraction of dynamic instruction information (using PIN).
Similarly, gather_scatter is split into separate files for
dynamic and static decoding. In preparation of supporting
additional frontends that need to resuse the static
instruction decoding.