### PR TITLE
Fix icache bug when icache breaking is disabled

### DIFF
--- a/src/icache_stage.c
+++ b/src/icache_stage.c
@@ -629,6 +629,7 @@ static inline Icache_State icache_issue_ops(Break_Reason* break_fetch,
             }
           }
         } else {
+          packet_break = PB_BREAK_AFTER;
           *break_fetch = BREAK_OFFPATH;
         }
 


### PR DESCRIPTION
A bug that was only happening when running scarab in trace mode, disabling ENABLE_ICACHE_PACKET_BREAKING and with perfect branch prediction turned off.