### PR TITLE
Checkpoint Loader Fixes

### DIFF
--- a/bin/scarab_launch.py
+++ b/bin/scarab_launch.py
@@ -132,12 +132,13 @@ class Pin:
     return self.cmd
 
   def __get_pin_checkpoint_command(self):
-    self.cmd = "{checkpoint_loader} {checkpoint_path} {socket} {core_id} {pin_tool}".format(
+    self.cmd = '{checkpoint_loader} {checkpoint_path} {socket} {core_id} {pin_tool} -pintool_args="{pintool_args}"'.format(
         checkpoint_loader=args.checkpoint_loader,
         checkpoint_path=self.program_path,
         socket=self.socket_path,
         core_id=self.core_id,
-        pin_tool=args.frontend_pin_tool
+        pin_tool=args.frontend_pin_tool,
+        pintool_args=args.pintool_args,
       )
 
     print("\nCore {core_id} is running checkpoint: {checkpoint_path}".format(


### PR DESCRIPTION
1) Scarab's pintool is now invoked directly in the parent process of the loaded checkpoint process, so even if yama ptrace_scope is restricted to 1, the checkpoint loader can attach the pintool.

2) Fixed scarab launch script to pass extra pintool arguments to the checkpoint loader