### PR TITLE
Added trace frontend support to launch and batch scripts

### DIFF
--- a/bin/checkpoint/convert_checkpoints_to_traces.py
+++ b/bin/checkpoint/convert_checkpoints_to_traces.py
@@ -1,0 +1,121 @@
+#  Copyright 2020 HPS/SAFARI Research Groups
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy of
+#  this software and associated documentation files (the "Software"), to deal in
+#  the Software without restriction, including without limitation the rights to
+#  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+#  of the Software, and to permit persons to whom the Software is furnished to do
+#  so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+
+import os
+import re
+
+from scarab_globals import *
+from scarab_globals.scarab_batch_types import *
+
+# Set the following variables before running.
+CHECKPOINT_DESCRIPTOR_PATH = ''
+OUTPUT_DIR = ''
+SUITE_NAME = ''
+
+def checkpoint_start_rip(path):
+  with open (path + '/main') as f:
+    for line in f:
+      m = re.match('\s*rip (0x[\da-f]+)', line.strip())
+      if not m: continue
+      return int(m.group(1), 16)
+  
+  raise RuntimeError(f'Did not find a value corresponding to the start rip in the checkpoint at {path}')
+
+def scarab_inst_limit(scarab_args):
+  m = re.search('--inst_limit ([\d]+)', scarab_args)
+  assert m
+  return int(m.group(1))
+
+def trace_line(name, path, scarab_args, weight):
+  return f'{name} = Trace("{name}", "{path}", scarab_args="{scarab_args}", weight={weight})\n'
+
+def benchmark_inp_line(benchmark):
+  return f'{benchmark.name} = Benchmark("{benchmark.name}", [{", ".join(c.name for c in benchmark.exec_list)}], weight={benchmark.weight})\n\n'
+
+def benchmark_line(benchmark):
+  return f'{benchmark.name} = Benchmark("{benchmark.name}", [{", ".join(b.name for b in benchmark.exec_list)}])\n\n'
+
+def suite_line(suite):
+  return f'{suite.name} = Suite("{suite.name}", [{", ".join(b.name for b in suite.exec_list)}])\n\n'
+
+def trace_command(checkpoint_path, trace_path, inst_limit, start_rip):
+  return Command(f'{scarab_paths.checkpoint_loader_bin} --run_external_pintool {checkpoint_path} {scarab_paths.pin_trace} --pintool_args "-start_rip {hex(start_rip)} -trace_len {inst_limit} -o {trace_path} "')
+
+class FakeScarabRun:
+  def __init__(self, cmd_list):
+    self.cmd_list = cmd_list
+    scarab_run_manager.register(self)
+
+  def create_snapshot(self):
+    return
+
+  def make(self):
+    return
+
+  def get_commands(self):
+    return self.cmd_list
+
+  def process_command_list(self):
+    return self.get_commands()
+
+  def print_progress(self):
+    assert False
+
+  def get_stats(self, flat=False):
+    assert False
+
+  def print_commands(self):
+    self.get_commands()
+    for cmd in self.cmd_list:
+      print(cmd)
+
+import_descriptor(CHECKPOINT_DESCRIPTOR_PATH)
+suite = globals()[SUITE_NAME]
+
+output_descriptor_txt = ''
+cmd_list = []
+
+for benchmark in suite.exec_list:
+  assert isinstance(benchmark, Benchmark)
+  for benchmark_inp in benchmark.exec_list:
+    assert isinstance(benchmark_inp, Benchmark)
+    for checkpoint in benchmark_inp.exec_list:
+      assert isinstance(checkpoint, Checkpoint)
+      start_rip = checkpoint_start_rip(checkpoint.path)
+      trace_path = f'{OUTPUT_DIR}/{os.path.basename(checkpoint.path)}_scarab_trace.bz2'
+      output_descriptor_txt += trace_line(checkpoint.name, trace_path, checkpoint.scarab_args, checkpoint.weight)
+      inst_limit = scarab_inst_limit(checkpoint.scarab_args)
+      cmd_list.append(trace_command(checkpoint.path, trace_path, inst_limit, start_rip))
+    output_descriptor_txt += benchmark_inp_line(benchmark_inp)
+
+for benchmark in suite.exec_list:
+  output_descriptor_txt += benchmark_line(benchmark)
+
+output_descriptor_txt += suite_line(suite)
+
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+with open(f'{OUTPUT_DIR}/descriptor.def', 'w') as f:
+  f.write(output_descriptor_txt)
+
+for cmd in cmd_list:
+  print(cmd)
+
+FakeScarabRun(cmd_list)
+BatchManager(processor_cores_per_node=20)

--- a/bin/scarab_globals/object_manager.py
+++ b/bin/scarab_globals/object_manager.py
@@ -88,5 +88,6 @@ class ScarabRunManager(ObjectManager):
 scarab_run_manager = ScarabRunManager()
 program_manager = ObjectManager()
 checkpoint_manager = ObjectManager()
+trace_manager = ObjectManager()
 mix_manager = ObjectManager()
 collection_manager = ObjectManager()

--- a/bin/scarab_globals/scarab_batch_types.py
+++ b/bin/scarab_globals/scarab_batch_types.py
@@ -203,6 +203,14 @@ class Checkpoint(Executable):
   def typestr(self):
     return "Checkpoint"
 
+class Trace(Executable):
+  def __init__(self, name, path, scarab_args="", pintool_args="", weight=1.0):
+    super().__init__(name, path, scarab_args, pintool_args, weight)
+    trace_manager.register(self)
+
+  def typestr(self):
+    return "Trace"
+
 class Program(Executable):
   def __init__(self, name, run_cmd, path=None, scarab_args="", pintool_args="", weight=1.0, copy=False):
     super().__init__(name, path, scarab_args, pintool_args, weight)
@@ -359,9 +367,11 @@ def get_program_or_checkpoint_options(job):
   run_exec = ""
 
   if type(job) is Program:
-    run_exec = " --program=\"" + job.run_cmd + "\""
+    run_exec = f' --program="{job.run_cmde}"'
   elif type(job) is Checkpoint:
-    run_exec = " --checkpoint=\"" + job.path + "\""
+    run_exec = f' --checkpoint="{job.path}"'
+  elif type(job) is Trace:
+    run_exec = f' --trace="{job.path}"'
   elif type(job) is Mix:
     for mix in job.mix_list:
       run_exec += " " + get_program_or_checkpoint_options(mix)

--- a/bin/scarab_globals/scarab_paths.py
+++ b/bin/scarab_globals/scarab_paths.py
@@ -53,6 +53,8 @@ src_dir                 = sim_dir + "/src"
 scarab_bin              = src_dir + "/scarab"
 pin_exec_dir            = src_dir + "/pin/pin_exec"
 pin_bin                 = pin_exec_dir   + "/obj-intel64/pin_exec.so"
+pin_trace_dir           = src_dir + "/pin/pin_trace"
+pin_trace               = pin_trace_dir  + "/obj-intel64/gen_trace.so"
 
 checkpoint_creator_dir  = utils_dir + "/checkpoint/creator"
 checkpoint_loader_dir   = utils_dir + "/checkpoint/loader"

--- a/src/pin/pin_trace/gen_trace.cc
+++ b/src/pin/pin_trace/gen_trace.cc
@@ -59,8 +59,13 @@ END_LEGAL */
 #include <stdio.h>
 #include <string>
 
+#include "control_manager.H"
+#include "instlib.H"
 #include "pin.H"
 #include "pinplay.H"
+
+using namespace INSTLIB;
+using namespace CONTROLLER;
 
 #undef UNUSED   // there is a name conflict between PIN and Scarab
 #undef WARNING  // there is a name conflict between PIN and Scarab
@@ -91,17 +96,41 @@ KNOB<BOOL> KnobPinPlayReplayer(KNOB_MODE_WRITEONCE, "pintool", "replay", "0",
 KNOB<string> Knob_output(KNOB_MODE_WRITEONCE, "pintool", "o", "trace.bz2",
                          "trace outputfilename");
 
+// Trace start and end options
+KNOB<UINT64> KnobStartRip(
+  KNOB_MODE_WRITEONCE, "pintool", "start_rip", "0",
+  "If non-zero, redirect RIP to this address after attaching the pintool");
+KNOB<UINT64> KnobTraceLen(
+  KNOB_MODE_WRITEONCE, "pintool", "trace_len", "200000000",
+  "Maximum number of instructions in the generated trace");
+KNOB<UINT64> KnobFastForward(
+  KNOB_MODE_WRITEONCE, "pintool", "fast_forward", "0",
+  "Number of instructions to fast-forward before generating the trace");
+
 /*** globals ***/
 FILE* output_stream;
 
 ctype_pin_inst mailbox;
 bool           mailbox_full = false;
 
+bool    need_to_change_rip        = false;
+bool    skip_dumping_instructions = false;
+int64_t fast_forward_insts_left   = 0;
+int64_t trace_insts_left          = 0;
+
 /*** function definitions ***/
 INT32 Usage() {
   std::cerr << "This pin tool creates a trace that Scarab Trace frontend\n";
   std::cerr << KNOB_BASE::StringKnobSummary() << endl;
   return -1;
+}
+
+void change_rip(CONTEXT* ctx) {
+  std::cout << "Changing RIP to " << std::hex << KnobStartRip.Value() << "\n";
+  need_to_change_rip = false;
+  PIN_SetContextReg(ctx, REG_INST_PTR, KnobStartRip.Value());
+  PIN_RemoveInstrumentation();
+  PIN_ExecuteAt(ctx);
 }
 
 LOCALFUN VOID Fini(int n, void* v) {
@@ -114,7 +143,38 @@ LOCALFUN VOID Fini(int n, void* v) {
   }
 }
 
+void fast_forward_trace(UINT32 trace_size) {
+  fast_forward_insts_left -= trace_size;
+  if(fast_forward_insts_left < 500) {
+    std::cout << "Fast-forward almost done, switching to per instruction "
+                 "fast-forward.\n";
+    PIN_RemoveInstrumentation();
+  }
+}
+
+void fast_forward_ins() {
+  if(fast_forward_insts_left > 0) {
+    fast_forward_insts_left -= 1;
+    skip_dumping_instructions = true;
+  } else if(skip_dumping_instructions) {
+    std::cout << "Fast-forward finished, starting tracing\n";
+    skip_dumping_instructions = false;
+  }
+}
+
+void check_end_of_trace() {
+  if(trace_insts_left <= 0) {
+    std::cout << "Reaching trace length limit, terminating early.\n";
+    PIN_ExitApplication(0);
+  }
+
+  trace_insts_left -= 1;
+}
+
 void dump_instruction() {
+  if(skip_dumping_instructions)
+    return;
+
   ctype_pin_inst* info = pin_decoder_get_latest_inst();
   if(mailbox_full) {
     mailbox.instruction_next_addr = info->instruction_addr;
@@ -124,14 +184,33 @@ void dump_instruction() {
   mailbox_full = true;
 }
 
-void insert_instrumentation(TRACE trace, void* v) {
+template <typename Func>
+void for_ins_in_trace(const TRACE& trace, Func f) {
   for(BBL bbl = TRACE_BblHead(trace); BBL_Valid(bbl); bbl = BBL_Next(bbl)) {
     for(INS ins = BBL_InsHead(bbl); INS_Valid(ins); ins = INS_Next(ins)) {
+      f(ins);
+    }
+  }
+}
+
+void insert_instrumentation(TRACE trace, void* v) {
+  if(need_to_change_rip) {
+    for_ins_in_trace(trace, [](const INS& ins) {
+      INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)change_rip, IARG_CONTEXT,
+                     IARG_END);
+    });
+  } else if(fast_forward_insts_left > 500) {
+    TRACE_InsertCall(trace, IPOINT_BEFORE, (AFUNPTR)fast_forward_trace,
+                     IARG_UINT32, TRACE_NumIns(trace), IARG_END);
+  } else {
+    for_ins_in_trace(trace, [](const INS& ins) {
+      INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)fast_forward_ins, IARG_END);
+      INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)check_end_of_trace, IARG_END);
       pin_decoder_insert_analysis_functions(ins);
       if(output_stream) {
         INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)dump_instruction, IARG_END);
       }
-    }
+    });
   }
 }
 
@@ -150,10 +229,15 @@ int main(int argc, char* argv[]) {
     cout << "No trace specified. Only verifying opcodes." << endl;
   }
 
+  need_to_change_rip      = (KnobStartRip.Value() != 0);
+  trace_insts_left        = KnobTraceLen.Value();
+  fast_forward_insts_left = KnobFastForward.Value();
+
   pin_decoder_init(true, &std::cerr);
 
   TRACE_AddInstrumentFunction(insert_instrumentation, 0);
   PIN_AddFiniFunction(Fini, 0);
+
   PIN_StartProgram();
 
   return 0;


### PR DESCRIPTION
- Improved trace generator pintool to specify trace length, fast-forward, and immediate RIP change for compatability with the checkpoint loader.
- Added support for trace frontend in Scarab Launch
- A script for generating traces based on a SPEC checkpoint descriptor file.
- Added support for trace frontend in Scarab Batch scripts