### PR TITLE
Add new frontend to simulate memtrace traces captured with dynamorio.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/deps/xed"]
 	path = src/deps/xed
 	url = https://github.com/intelxed/xed.git
+[submodule "src/deps/dynamorio"]
+	path = src/deps/dynamorio
+	url = https://github.com/DynamoRIO/dynamorio.git

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Please see the [LICENSE](LICENSE) for more information.
 4. Running a single program on Scarab.
 5. Running multiple jobs locally or on a batch system. (coming soon!)
 6. Viewing batch job status and results. (coming soon!)
-7. Solutions to common Scarab problems.
+7. [Simulating dynamorio memtraces](docs/memtrace.md)
+8. Solutions to common Scarab problems.
 
 ## Contributing to Scarab
 

--- a/docs/memtrace.md
+++ b/docs/memtrace.md
@@ -1,0 +1,26 @@
+# Memtrace Frontend
+
+Scarab supports simulating instruction and memory address traces in the memtrace format,
+obtained with dynamorio. Memtraces contain basic block (BBL) PC addresses of all executed
+BBLs and memory addresses of all instructions accessing main memory. To simulate a
+memtrace, scarab needs to be provided with the trace and a module.log file that contains
+the absolute paths to the traced binary and all referenced libraries.
+
+##### Compiling the Memtrace Frontend
+1. Install additional dependencies: snappy, dl, config++, z, rt, pthread
+2. $ export SCARAB_ENABLE_MEMTRACE=1
+3. $ make (from the main scarab directory)
+
+##### Capturing Memtraces
+1. Trace a workload
+$ <SCARAB_BUILD_DIR>/deps/dynamorio/bin64/drrun -c <SCARAB_BUILD_DIR>deps/dynamorio/clients/lib64/release/libdrmemtrace.so -offline -trace_after_instrs 1M -exit_after_tracing 1G -- <TRACED_WORKLOAD>
+2. Copy binaries and shared libs and convert trace 
+$ sh run_portabilize_trace.sh (run from the directory that contains the drmemtrace.* directory).
+3. Fix absolute paths in modules.log (needs to be performed whenever the bin directory is moved)
+$ sh run_update_trace.sh
+
+##### Simulating Memtraces with Scarab
+$ scarab
+--frontend memtrace --fetch_off_path_ops 0
+--cbp_trace_r0=<TRACE_DIRECTORY>
+--memtrace_modules_log=<MODULES_LOG_FILE_DIRECTORY>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,15 +7,30 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_C_FLAGS_SCARABOPT   "-O3 -DNO_DEBUG")
-set(CMAKE_CXX_FLAGS_SCARABOPT "-O3 -DNO_DEBUG")
-set(CMAKE_C_FLAGS_VALGRIND    "-O0 -g3")
-set(CMAKE_CXX_FLAGS_VALGRIND  "-O0 -g3")
-set(CMAKE_C_FLAGS_GPROF       "${CMAKE_CXX_FLAGS_SCARABOPT} -pg -g3")
-set(CMAKE_CXX_FLAGS_GPROF     "${CMAKE_CXX_FLAGS_SCARABOPT} -pg -g3")
+set(enable_memtrace 0)
+set(flags_enable_memtrace "")
 
-set(warn_flags -Wall -Wunused -Wno-long-long -Wpointer-arith -Werror)
-set(warn_c_flags ${warn_flags} -Wmissing-declarations -Wmissing-prototypes -Wimplicit -Wno-unused-but-set-variable -Wno-maybe-uninitialized)
+if(DEFINED ENV{SCARAB_ENABLE_MEMTRACE})
+  set(flags_enable_memtrace "-DENABLE_MEMTRACE")
+endif()
+
+set(CMAKE_C_FLAGS_SCARABOPT   "-O3 -DNO_DEBUG -DLINUX -DX86_64 ${flags_enable_memtrace}")
+set(CMAKE_CXX_FLAGS_SCARABOPT "-O3 -DNO_DEBUG -DLINUX -DX86_64 ${flags_enable_memtrace}")
+set(CMAKE_C_FLAGS_VALGRIND    "-O0 -g3 -DLINUX -DX86_64 ${flags_enable_memtrace}")
+set(CMAKE_CXX_FLAGS_VALGRIND  "-O0 -g3 -DLINUX -DX86_64 ${flags_enable_memtrace}")
+set(CMAKE_C_FLAGS_GPROF       "${CMAKE_CXX_FLAGS_SCARABOPT} -pg -g3 ${flags_enable_memtrace}")
+set(CMAKE_CXX_FLAGS_GPROF     "${CMAKE_CXX_FLAGS_SCARABOPT} -pg -g3 ${flags_enable_memtrace}")
+
+#build dependencies with default warn flags, otherwise dynamorio will not build
+add_subdirectory(deps)
+
+set(warn_flags -Wall -Wunused -Wno-long-long
+  -Wpointer-arith
+  -Werror)
+set(warn_c_flags ${warn_flags}
+  -Wmissing-declarations
+  -Wmissing-prototypes
+  -Wimplicit -Wno-unused-but-set-variable -Wno-maybe-uninitialized)
 set(warn_cxx_flags ${warn_flags})
 
 add_compile_options(
@@ -23,12 +38,14 @@ add_compile_options(
         "$<$<COMPILE_LANGUAGE:CXX>:${warn_cxx_flags}>"
 )
 
-add_subdirectory(deps)
 add_subdirectory(ramulator)
 add_subdirectory(pin/pin_lib)
 add_subdirectory(pin/pin_exec/testing)
 
 set(scarab_dirs bp debug bp/template_lib dvfs frontend globals isa libs memory power prefetcher .)
+if(DEFINED ENV{SCARAB_ENABLE_MEMTRACE})
+  set(scarab_dirs ${scarab_dirs} frontend/memtrace)
+endif()
 
 set(srcs)
 foreach(dir IN LISTS scarab_dirs) 
@@ -43,10 +60,17 @@ endforeach()
 add_executable(scarab 
     ${srcs}
 )
-target_include_directories(scarab PRIVATE .) 
+
+target_include_directories(scarab PRIVATE .)
+if(DEFINED ENV{SCARAB_ENABLE_MEMTRACE})
+  target_include_directories(scarab PRIVATE memtrace ${CMAKE_BINARY_DIR}/deps/dynamorio/include/)
+endif()
+
 target_link_libraries(scarab
     PRIVATE
         ramulator
         pin_lib_for_scarab
 )
-
+if(DEFINED ENV{SCARAB_ENABLE_MEMTRACE})
+  target_link_libraries(scarab PRIVATE dynamorio memtrace)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,9 +62,6 @@ add_executable(scarab
 )
 
 target_include_directories(scarab PRIVATE .)
-if(DEFINED ENV{SCARAB_ENABLE_MEMTRACE})
-  target_include_directories(scarab PRIVATE memtrace ${CMAKE_BINARY_DIR}/deps/dynamorio/include/)
-endif()
 
 target_link_libraries(scarab
     PRIVATE

--- a/src/core.param.def
+++ b/src/core.param.def
@@ -286,5 +286,7 @@ DEF_PARAM(cbp_trace_r61, CBP_TRACE_R61, char*, string, NULL, )
 DEF_PARAM(cbp_trace_r62, CBP_TRACE_R62, char*, string, NULL, )
 DEF_PARAM(cbp_trace_r63, CBP_TRACE_R63, char*, string, NULL, )
 
+DEF_PARAM(memtrace_modules_log, MEMTRACE_MODULES_LOG, char*, string, NULL, )
+
 DEF_PARAM(dumb_core_on, DUMB_CORE_ON, Flag, Flag, FALSE, )
 DEF_PARAM(dumb_core, DUMB_CORE, uns, uns, 1, )

--- a/src/deps/CMakeLists.txt
+++ b/src/deps/CMakeLists.txt
@@ -25,3 +25,45 @@ set($ENV{TARGET} ia32)
 add_library(xed INTERFACE)
 target_include_directories(xed INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/xed/include/public/xed/)
 target_include_directories(xed INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/xed/obj/)
+target_link_libraries(xed INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/xed/obj/libxed.a)
+
+if(DEFINED ENV{SCARAB_ENABLE_MEMTRACE})
+  add_subdirectory(dynamorio)
+  add_library(memtrace INTERFACE)
+
+  target_include_directories(memtrace
+    INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/dynamorio/ext/drcovlib/
+    ${CMAKE_CURRENT_SOURCE_DIR}/dynamorio/ext/drmgr/
+    ${CMAKE_CURRENT_SOURCE_DIR}/dynamorio/ext/drcontainers/
+    ${CMAKE_CURRENT_SOURCE_DIR}/dynamorio/core/lib/
+    ${CMAKE_CURRENT_SOURCE_DIR}/dynamorio/clients/drcachesim/reader/
+    ${CMAKE_CURRENT_SOURCE_DIR}/dynamorio/clients/drcachesim/common/
+    ${CMAKE_CURRENT_SOURCE_DIR}/dynamorio/clients/drcachesim/tracer/
+    ${CMAKE_CURRENT_SOURCE_DIR}/dynamorio/clients/drcachesim/
+    )
+
+  target_link_libraries(memtrace
+    INTERFACE
+    drmemtrace_raw2trace
+    directory_iterator
+    drfrontendlib
+    drutil_static
+    drmgr_static
+    drmemfuncs
+    dynamorio_static
+    drlibc
+    drcovlib_static
+    drx_static
+    drreg_static
+    drcontainers
+    drmemtrace_analyzer
+    xed
+    snappy
+    dl
+    config++
+    z
+    rt
+    pthread
+    )
+endif()

--- a/src/deps/CMakeLists.txt
+++ b/src/deps/CMakeLists.txt
@@ -33,6 +33,7 @@ if(DEFINED ENV{SCARAB_ENABLE_MEMTRACE})
 
   target_include_directories(memtrace
     INTERFACE
+    ${CMAKE_BINARY_DIR}/deps/dynamorio/include/
     ${CMAKE_CURRENT_SOURCE_DIR}/dynamorio/ext/drcovlib/
     ${CMAKE_CURRENT_SOURCE_DIR}/dynamorio/ext/drmgr/
     ${CMAKE_CURRENT_SOURCE_DIR}/dynamorio/ext/drcontainers/

--- a/src/frontend/frontend.c
+++ b/src/frontend/frontend.c
@@ -42,6 +42,10 @@
 #include "statistics.h"
 #include "thread.h"
 
+#ifdef ENABLE_MEMTRACE
+#include "frontend/memtrace/memtrace_fe.h"
+#endif
+
 /**************************************************************************************/
 /* Macros */
 
@@ -65,6 +69,12 @@ void frontend_init() {
       trace_init();
       break;
     }
+#ifdef ENABLE_MEMTRACE
+    case FE_MEMTRACE: {
+      memtrace_init();
+      break;
+    }
+#endif
     default:
       ASSERT(0, 0);
       break;
@@ -81,6 +91,12 @@ void frontend_done(Flag* retired_exit) {
       trace_done();
       break;
     }
+#ifdef ENABLE_MEMTRACE
+    case FE_MEMTRACE: {
+      memtrace_done();
+      break;
+    }
+#endif
     default:
       ASSERT(0, 0);
       break;

--- a/src/frontend/frontend_table.def
+++ b/src/frontend/frontend_table.def
@@ -29,3 +29,6 @@
 // Format: enum name, text name, function name prefix
 FRONTEND_IMPL(PIN_EXEC_DRIVEN, "pin_exec_driven", pin_exec_driven)
 FRONTEND_IMPL(TRACE,           "trace",           trace)
+#ifdef ENABLE_MEMTRACE
+FRONTEND_IMPL(MEMTRACE,	       "memtrace",	  memtrace)
+#endif

--- a/src/frontend/memtrace/memtrace_fe.cc
+++ b/src/frontend/memtrace/memtrace_fe.cc
@@ -1,0 +1,302 @@
+/* Copyright 2020 University of California Santa Cruz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/***************************************************************************************
+ * File         : frontend/memtrace_fe.cc
+ * Author       : Heiner Litz
+ * Date         : 05/15/2020
+ * Description  : Frontend to simulate traces in memtrace format
+ ***************************************************************************************/
+
+#include "debug/debug.param.h"
+#include "debug/debug_macros.h"
+#include "globals/assert.h"
+#include "globals/global_defs.h"
+#include "globals/global_types.h"
+#include "globals/global_vars.h"
+#include "globals/utils.h"
+
+#include "bp/bp.h"
+#include "bp/bp.param.h"
+#include "ctype_pin_inst.h"
+#include "frontend/memtrace/memtrace_fe.h"
+#include "isa/isa.h"
+#include "statistics.h"
+#include "pin/pin_lib/uop_generator.h"
+#include "pin/pin_lib/x86_decoder.h"
+
+#define DR_DO_NOT_DEFINE_int64
+
+#include "frontend/memtrace/memtrace_trace_reader_memtrace.h"
+
+/**************************************************************************************/
+/* Macros */
+
+#define DEBUG(proc_id, args...) _DEBUG(proc_id, DEBUG_TRACE_READ, ##args)
+
+//#define PRINT_INSTRUCTION_INFO
+/**************************************************************************************/
+/* Global Variables */
+
+char* trace_files[MAX_NUM_PROCS];
+TraceReader *trace_readers[MAX_NUM_PROCS];
+ctype_pin_inst* next_pi;
+uint64_t ins_id = 0;
+uint64_t prior_tid = 0;
+uint64_t prior_pid = 0;
+
+/**************************************************************************************/
+/* Private Functions */
+
+void fill_in_dynamic_info(ctype_pin_inst* info, const InstInfo *insi) {
+    uint8_t ld = 0;
+    uint8_t st = 0;
+
+    // Note: should be overwritten for a taken control flow instruction
+    info->instruction_addr = insi->pc;
+    info->instruction_next_addr = insi->target;
+    info->actually_taken = insi->taken;
+    info->branch_target = insi->target;
+    info->inst_uid = ins_id;
+
+#ifdef PRINT_INSTRUCTION_INFO
+    std::cout << std::hex << info->instruction_addr << " Next " << info->instruction_next_addr
+	      << " size " << (uint32_t)info->size << " taken " << (uint32_t)info->actually_taken
+	      << " target " << info->branch_target << " pid " << insi->pid << " tid " << insi->tid
+	      << " asm " << std::string(xed_iclass_enum_t2str(xed_decoded_inst_get_iclass(insi->ins)))
+	      << " uid " << std::dec << info->inst_uid << std::endl;
+#endif
+
+    if (xed_decoded_inst_get_iclass(insi->ins) == XED_ICLASS_RET_FAR ||
+	xed_decoded_inst_get_iclass(insi->ins) == XED_ICLASS_RET_NEAR)
+      info->actually_taken = 1;
+
+    for (uint8_t op = 0; op < xed_decoded_inst_number_of_memory_operands(insi->ins); op++) {
+	//predicated true ld/st are handled just as regular ld/st
+	if(xed_decoded_inst_mem_read(insi->ins, op) && !insi->mem_used[op]) {
+	    //Handle predicated stores specially?
+	    info->ld_vaddr[ld++] = insi->mem_addr[op];
+	}
+	else if(xed_decoded_inst_mem_read(insi->ins, op)) {
+	    info->ld_vaddr[ld++] = insi->mem_addr[op];
+	}
+	if(xed_decoded_inst_mem_written(insi->ins, op) && !insi->mem_used[op]) {
+	    //Handle predicated stores specially?
+	    info->st_vaddr[st++] = insi->mem_addr[op];
+	}
+	else if(xed_decoded_inst_mem_written(insi->ins, op)) {
+	    info->st_vaddr[st++] = insi->mem_addr[op];
+	}
+    }
+}
+
+int ffwd(const xed_decoded_inst_t* ins) {
+  if (!FAST_FORWARD) {
+    return 0;
+  }
+  if(XED_INS_Opcode(ins) == XED_ICLASS_XCHG && XED_INS_OperandReg(ins, 0) == XED_REG_RCX &&
+     XED_INS_OperandReg(ins, 1) == XED_REG_RCX) {
+    return 0;
+  }
+  if(ins_id == FAST_FORWARD_TRACE_INS) {
+    return 0;
+  }
+  return 1;
+}
+
+int roi(const xed_decoded_inst_t* ins) {
+  if(XED_INS_Opcode(ins) == XED_ICLASS_XCHG && XED_INS_OperandReg(ins, 0) == XED_REG_RCX &&
+     XED_INS_OperandReg(ins, 1) == XED_REG_RCX) {
+    return 1;
+  }
+  return 0;
+}
+
+int memtrace_trace_read(int proc_id, ctype_pin_inst* next_pi) {
+  InstInfo *insi;
+
+  do {
+     insi = const_cast<InstInfo *>(trace_readers[proc_id]->nextInstruction());
+     ins_id++;
+     if (!insi->valid) {
+       insi = const_cast<InstInfo *>(trace_readers[proc_id]->nextInstruction());
+       ins_id++;
+       return 0; //end of trace
+     }
+  } while (insi->pid != prior_pid || insi->tid != prior_tid);
+
+  memset(next_pi, 0, sizeof(ctype_pin_inst));
+  fill_in_dynamic_info(next_pi, insi);
+  fill_in_basic_info(next_pi, insi->ins);
+  uint32_t max_op_width = add_dependency_info(next_pi, insi->ins);
+  fill_in_simd_info(next_pi, insi->ins, max_op_width);
+  apply_x87_bug_workaround(next_pi, insi->ins);
+  fill_in_cf_info(next_pi, insi->ins);
+  print_err_if_invalid(next_pi, insi->ins);
+
+  //End of ROI
+  if (roi(insi->ins))
+    return 0;
+
+  return 1;
+}
+
+
+/**************************************************************************************/
+/* trace_init() */
+
+void memtrace_init(void) {
+  /*ASSERTM(0, !FETCH_OFF_PATH_OPS,
+          "Trace frontend does not support wrong path. Turn off "
+          "FETCH_OFF_PATH_OPS\n");
+  */
+
+  uop_generator_init(NUM_CORES);
+  init_x86_decoder(nullptr);
+  init_x87_stack_delta();
+
+  next_pi = (ctype_pin_inst*)malloc(NUM_CORES * sizeof(ctype_pin_inst));
+
+  /* temp variable needed for easy initialization syntax */
+  char* tmp_trace_files[MAX_NUM_PROCS] = {
+    CBP_TRACE_R0,  CBP_TRACE_R1,  CBP_TRACE_R2,  CBP_TRACE_R3,  CBP_TRACE_R4,
+    CBP_TRACE_R5,  CBP_TRACE_R6,  CBP_TRACE_R7,  CBP_TRACE_R8,  CBP_TRACE_R9,
+    CBP_TRACE_R10, CBP_TRACE_R11, CBP_TRACE_R12, CBP_TRACE_R13, CBP_TRACE_R14,
+    CBP_TRACE_R15, CBP_TRACE_R16, CBP_TRACE_R17, CBP_TRACE_R18, CBP_TRACE_R19,
+    CBP_TRACE_R20, CBP_TRACE_R21, CBP_TRACE_R22, CBP_TRACE_R23, CBP_TRACE_R24,
+    CBP_TRACE_R25, CBP_TRACE_R26, CBP_TRACE_R27, CBP_TRACE_R28, CBP_TRACE_R29,
+    CBP_TRACE_R30, CBP_TRACE_R31, CBP_TRACE_R32, CBP_TRACE_R33, CBP_TRACE_R34,
+    CBP_TRACE_R35, CBP_TRACE_R36, CBP_TRACE_R37, CBP_TRACE_R38, CBP_TRACE_R39,
+    CBP_TRACE_R40, CBP_TRACE_R41, CBP_TRACE_R42, CBP_TRACE_R43, CBP_TRACE_R44,
+    CBP_TRACE_R45, CBP_TRACE_R46, CBP_TRACE_R47, CBP_TRACE_R48, CBP_TRACE_R49,
+    CBP_TRACE_R50, CBP_TRACE_R51, CBP_TRACE_R52, CBP_TRACE_R53, CBP_TRACE_R54,
+    CBP_TRACE_R55, CBP_TRACE_R56, CBP_TRACE_R57, CBP_TRACE_R58, CBP_TRACE_R59,
+    CBP_TRACE_R60, CBP_TRACE_R61, CBP_TRACE_R62, CBP_TRACE_R63,
+  };
+  if(DUMB_CORE_ON) {
+    // avoid errors by specifying a trace known to be good
+    tmp_trace_files[DUMB_CORE] = tmp_trace_files[0];
+  }
+
+  for(uns proc_id = 0; proc_id < MAX_NUM_PROCS; proc_id++) {
+    trace_files[proc_id] = tmp_trace_files[proc_id];
+  }
+  for(uns proc_id = 0; proc_id < NUM_CORES; proc_id++) {
+    memtrace_setup(proc_id);
+  }
+}
+
+void memtrace_setup(uns proc_id) {
+  std::string path(trace_files[proc_id]);
+  std::string trace(path);
+  std::string binaries(MEMTRACE_MODULES_LOG);
+
+  trace_readers[proc_id] = new TraceReaderMemtrace(trace, binaries, 1);
+
+  //FFWD
+  const InstInfo *insi = trace_readers[proc_id]->nextInstruction();
+
+  if(FAST_FORWARD) {
+    std::cout << "Enter fast forward " << ins_id << std::endl;
+  }
+
+  while (!insi->valid || ffwd(insi->ins)) {
+    insi = trace_readers[proc_id]->nextInstruction();
+    ins_id++;
+    if ((ins_id % 10000000) == 0)
+      std::cout << "Fast forwarded " << ins_id << " instructions." << std::endl;
+  }
+
+  if(FAST_FORWARD) {
+    std::cout << "Exit fast forward " << ins_id << std::endl;
+  }
+
+  prior_pid = insi->pid;
+  prior_tid = insi->tid;
+  assert(prior_tid);
+  assert(prior_pid);
+  memtrace_trace_read(proc_id, &next_pi[proc_id]);
+}
+
+/**************************************************************************************/
+/* trace_next_fetch_addr */
+
+Addr memtrace_next_fetch_addr(uns proc_id) {
+  return next_pi[proc_id].instruction_addr;
+}
+
+/**************************************************************************************/
+/* trace done */
+
+void memtrace_done() {
+  uns proc_id;
+  for(proc_id = 0; proc_id < NUM_CORES; proc_id++) {
+    //delete trace_readers[proc_id];
+  }
+  printf("done\n");
+}
+
+void memtrace_close_trace_file(uns proc_id) {
+  //delete trace_readers[proc_id];
+  printf("close\n");
+}
+
+Flag memtrace_can_fetch_op(uns proc_id) {
+  assert(proc_id == 0);
+  return !(uop_generator_get_eom(proc_id) && trace_read_done[proc_id]);
+}
+
+void memtrace_fetch_op(uns proc_id, Op* op) {
+  if(uop_generator_get_bom(proc_id)) {
+    //ASSERT(proc_id, !trace_read_done[proc_id] && !reached_exit[proc_id]);
+    uop_generator_get_uop(proc_id, op, &next_pi[proc_id]);
+  } else {
+    uop_generator_get_uop(proc_id, op, NULL);
+  }
+
+  if(uop_generator_get_eom(proc_id)) {
+    int success = memtrace_trace_read(proc_id, &next_pi[proc_id]);
+    static int ins = 0;
+    ins++;
+    if(!success) {
+      trace_read_done[proc_id] = TRUE;
+      reached_exit[proc_id]    = TRUE;
+      std::cout << "Reached end of trace" << std::endl;
+    }
+  }
+}
+
+void memtrace_redirect(uns proc_id, uns64 inst_uid, Addr fetch_addr) {
+  assert(0);
+  //FATAL_ERROR(proc_id, "Trace frontend does not support wrong path. Turn off "
+  //                     "FETCH_OFF_PATH_OPS\n");
+}
+
+void memtrace_recover(uns proc_id, uns64 inst_uid) {
+  assert(0);
+  //FATAL_ERROR(proc_id, "Trace frontend does not support wrong path. Turn off "
+  //                     "FETCH_OFF_PATH_OPS\n");
+}
+
+void memtrace_retire(uns proc_id, uns64 inst_uid) {
+  // Trace frontend does not need to communicate to PIN which instruction are
+  // retired.
+}

--- a/src/frontend/memtrace/memtrace_fe.h
+++ b/src/frontend/memtrace/memtrace_fe.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 HPS/SAFARI Research Groups
+/* Copyright 2020 University of California Santa Cruz
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,39 +20,48 @@
  */
 
 /***************************************************************************************
- * File         : frontend/frontend_intf.c
- * Author       : HPS Research Group
+ * File         : frontend/memtrace_fe.h
+ * Author       : Heiner Litz
  * Date         :
  * Description  :
  ***************************************************************************************/
 
-#include "frontend/frontend_intf.h"
-#include "general.param.h"
-#include "globals/global_defs.h"
+#ifndef __MEMTRACE_FE_H__
+#define __MEMTRACE_FE_H__
 
-/* Include headers of all the implementations here */
-#include "frontend/pin_exec_driven_fe.h"
-#include "frontend/pin_trace_fe.h"
+#include "globals/global_types.h"
 
-#ifdef ENABLE_MEMTRACE
-#include "frontend/memtrace/memtrace_fe.h"
+/**************************************************************************************/
+/* Forward Declarations */
+
+struct Trace_Uop_struct;
+typedef struct Trace_Uop_struct Trace_Uop;
+struct Op_struct;
+
+/**************************************************************************************/
+/* Prototypes */
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-Frontend_Impl frontend_table[] = {
-#define FRONTEND_IMPL(id, name, prefix) \
-  {name,                                \
-   prefix##_next_fetch_addr,            \
-   prefix##_can_fetch_op,               \
-   prefix##_fetch_op,                   \
-   prefix##_redirect,                   \
-   prefix##_recover,                    \
-   prefix##_retire},
-#include "frontend/frontend_table.def"
-#undef FRONTEND_IMPL
-};
+void memtrace_init(void);
 
-Frontend_Impl* frontend = NULL;
+/* Implementing the frontend interface */
+Addr memtrace_next_fetch_addr(uns proc_id);
+Flag memtrace_can_fetch_op(uns proc_id);
+void memtrace_fetch_op(uns proc_id, Op* op);
+void memtrace_redirect(uns proc_id, uns64 inst_uid, Addr fetch_addr);
+void memtrace_recover(uns proc_id, uns64 inst_uid);
+void memtrace_retire(uns proc_id, uns64 inst_uid);
 
-void frontend_intf_init() {
-  frontend = &frontend_table[FRONTEND];
+/* For restarting of memtraces */
+void memtrace_done(void);
+void memtrace_close_trace_file(uns proc_id);
+void memtrace_setup(uns proc_id);
+
+#ifdef __cplusplus
 }
+#endif
+
+#endif

--- a/src/frontend/memtrace/memtrace_trace_reader.cc
+++ b/src/frontend/memtrace/memtrace_trace_reader.cc
@@ -1,0 +1,385 @@
+/* Copyright 2020 University of California Santa Cruz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/***************************************************************************************
+ * File         : frontend/memtrace_trace_reader.cc
+ * Author       : Heiner Litz
+ * Date         : 05/15/2020
+ * Description  :
+ ***************************************************************************************/
+
+#include "frontend/memtrace/memtrace_trace_reader.h"
+#include <algorithm>
+#include <cstring>
+#include <fcntl.h>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "assert.h"
+#include "elf.h"
+//#include "log.h"
+
+#define warn(...) printf(__VA_ARGS__)
+#define panic(...) printf(__VA_ARGS__)
+
+
+using std::endl;
+using std::get;
+using std::ifstream;
+using std::ignore;
+using std::make_pair;
+using std::tie;
+using std::unique_ptr;
+
+static bool       xedInitDone = false;
+static std::mutex initMutex;
+
+// A non-reader
+TraceReader::TraceReader() :
+    trace_ready_(false), binary_ready_(false), skipped_(0) {
+  init("");
+}
+
+// Trace + single binary
+TraceReader::TraceReader(const std::string& _trace, const std::string& _binary,
+                         uint64_t _offset, uint32_t _buf_size) :
+    trace_ready_(false),
+    binary_ready_(true), warn_not_found_(1), skipped_(0), buf_size_(_buf_size) {
+  binaryFileIs(_binary, _offset);
+}
+
+// Trace + multiple binaries
+TraceReader::TraceReader(const std::string& _trace,
+                         const std::string& _binary_group_path,
+                         uint32_t           _buf_size) :
+    trace_ready_(false),
+    binary_ready_(true), warn_not_found_(1), skipped_(0), buf_size_(_buf_size) {
+}
+
+TraceReader::~TraceReader() {
+  clearBinaries();
+  if(skipped_ > 0) {
+    warn("Skipped %lu stray memory references\n", skipped_);
+  }
+}
+
+bool TraceReader::operator!() {
+  // Return true if there was an initialization error
+  return !(trace_ready_ && binary_ready_);
+}
+
+void TraceReader::init(const std::string& _trace) {
+  // Initialize XED only once
+  initMutex.lock();
+  if(!xedInitDone) {
+    xed_tables_init();
+    xedInitDone = true;
+  }
+  initMutex.unlock();
+
+  // Set the XED machine mode to 64-bit
+  xed_state_init2(&xed_state_, XED_MACHINE_MODE_LONG_64, XED_ADDRESS_WIDTH_64b);
+
+  // Clear the 'invalid' record (memset() would do too)
+  invalid_info_.pc           = 0;
+  invalid_info_.ins          = nullptr;
+  invalid_info_.pid          = 0;
+  invalid_info_.tid          = 0;
+  invalid_info_.target       = 0;
+  invalid_info_.mem_addr[0]  = 0;
+  invalid_info_.mem_addr[1]  = 0;
+  invalid_info_.mem_used[0]  = false;
+  invalid_info_.mem_used[1]  = false;
+  invalid_info_.custom_op    = CustomOp::NONE;
+  invalid_info_.taken        = false;
+  invalid_info_.unknown_type = false;
+  invalid_info_.valid        = false;
+
+  if(_trace.size())
+    traceFileIs(_trace);
+  init_buffer();
+}
+
+void TraceReader::traceFileIs(const std::string& _trace) {
+  trace_       = _trace;
+  trace_ready_ = initTrace();
+}
+
+void TraceReader::binaryFileIs(const std::string& _binary, uint64_t _offset) {
+  clearBinaries();
+  if(_binary.empty()) {
+    // An absent binary is allowed
+    binary_ready_ = true;
+  } else {
+    binary_ready_ = initBinary(_binary, _offset);
+  }
+}
+
+void TraceReader::clearBinaries() {
+  // Unmap all existing files
+  for(auto& binary : binaries_) {
+    auto& map_info = binary.second;
+    if(munmap(map_info.first, map_info.second) == -1) {
+      panic("munmap: %s", strerror(errno));
+    }
+  }
+  binaries_.clear();
+  sections_.clear();
+}
+
+bool TraceReader::initBinary(const std::string& _name, uint64_t _offset) {
+  // Load the input file to memory
+  int fd = open(_name.c_str(), O_RDONLY);
+  if(fd == -1) {
+    panic("Could not open '%s': %s", _name.c_str(), strerror(errno));
+    return false;
+  }
+  struct stat sb;
+  if(fstat(fd, &sb) == -1) {
+    panic("fstat: %s", strerror(errno));
+    return false;
+  }
+  uint64_t size = static_cast<uint64_t>(sb.st_size);
+  if(size == 0) {
+    warn("Input file '%s' is empty", _name.c_str());
+    if(close(fd) == -1) {
+      panic("close: %s", strerror(errno));
+    }
+    return false;
+  }
+  uint8_t* data = static_cast<uint8_t*>(
+    mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0));
+  if(data == MAP_FAILED) {
+    panic("mmap: %s", strerror(errno));
+    return false;
+  }
+  if(close(fd) == -1) {
+    panic("close: %s", strerror(errno));
+    return false;
+  }
+  binaries_.emplace(_name, make_pair(data, size));
+
+  // Parse the ELF structures in the file
+  if(size < sizeof(Elf64_Ehdr)) {
+    panic("File is too small to hold an ELF header");
+    return false;
+  }
+  Elf64_Ehdr* hdr = reinterpret_cast<Elf64_Ehdr*>(data);
+  if(hdr->e_machine != EM_X86_64) {
+    panic("Expected ELF binary type 'EM_X86_64'");
+    return false;
+  }
+  Elf64_Off shoff = hdr->e_shoff;  // section header table offset
+  if(size < shoff + (hdr->e_shnum * sizeof(Elf64_Shdr))) {
+    panic("ELF file is too small for section headers");
+    return false;
+  }
+
+  Elf64_Shdr* shdr = reinterpret_cast<Elf64_Shdr*>(data + shoff);
+  for(Elf64_Half i = 0; i < hdr->e_shnum; i++) {
+    if((shdr[i].sh_type == SHT_PROGBITS) &&
+       (shdr[i].sh_flags & SHF_EXECINSTR)) {
+      // An executable ("text") section
+      Elf64_Off   sec_offset = shdr[i].sh_offset;
+      Elf64_Xword sec_size   = shdr[i].sh_size;
+      if(size < sec_offset + sec_size) {
+        panic("ELF file is too small for section %u", i);
+        return false;
+      }
+      // Save the starting virtual address, size, and location in memory
+      uint64_t base_addr = shdr[i].sh_addr + _offset;
+      sections_.emplace_back(base_addr, sec_size, data + sec_offset);
+    }
+  }
+  return true;
+}
+
+void TraceReader::fillCache(uint64_t _vAddr, uint8_t _reported_size,
+                            uint8_t* inst_bytes) {
+  uint64_t size;
+  uint8_t* loc;
+  if(inst_bytes != NULL || locationForVAddr(_vAddr, &loc, &size)) {
+    xed_map_.emplace(_vAddr, make_tuple(0, false, false, false,
+                                        make_unique<xed_decoded_inst_t>()));
+    xed_decoded_inst_t* ins = get<MAP_XED>(xed_map_.at(_vAddr)).get();
+    xed_decoded_inst_zero_set_mode(ins, &xed_state_);
+    if(inst_bytes != NULL) {
+      loc  = inst_bytes;
+      size = _reported_size;
+    }
+    xed_error_enum_t res;
+    if(inst_bytes != NULL)
+      res = xed_decode(ins, inst_bytes, _reported_size);
+    else
+      res = xed_decode(ins, loc, size);
+
+    if(res != XED_ERROR_NONE) {
+      warn("XED decode error for 0x%lx: %s %u", _vAddr,
+           xed_error_enum_t2str(res), _reported_size);
+    }
+    // Record if this instruction requires memory operands, since the trace
+    // will deliver it in additional pieces
+    uint32_t n_mem_ops = xed_decoded_inst_number_of_memory_operands(ins);
+    if(n_mem_ops > 0) {
+      // NOPs are special and don't actually cause memory accesses
+      xed_category_enum_t category = xed_decoded_inst_get_category(ins);
+      if(category != XED_CATEGORY_NOP && category != XED_CATEGORY_WIDENOP) {
+        uint32_t n_used_mem_ops = 0;  // 'lea' doesn't actually touch memory
+        for(uint32_t i = 0; i < n_mem_ops; i++) {
+          if(xed_decoded_inst_mem_read(ins, i)) {
+            n_used_mem_ops++;
+          }
+          if(xed_decoded_inst_mem_written(ins, i)) {
+            n_used_mem_ops++;
+          }
+        }
+        if(n_used_mem_ops > 0) {
+          if(n_used_mem_ops > 2) {
+            warn("Unexpected %u memory operands for 0x%lx\n", n_used_mem_ops,
+                 _vAddr);
+          }
+          get<MAP_MEMOPS>(xed_map_.at(_vAddr)) = n_used_mem_ops;
+        }
+      }
+    }
+    auto& xed_tuple = xed_map_[_vAddr];
+    // Record if this instruction is a conditional branch
+    bool is_cond_br          = (xed_decoded_inst_get_category(ins) ==
+                       XED_CATEGORY_COND_BR);
+    get<MAP_COND>(xed_tuple) = is_cond_br;
+
+    // Record if this instruction is a 'rep' type, which may indicate a
+    // variable number of memory records for input formats like memtrace
+    bool is_rep = xed_decoded_inst_get_attribute(ins, XED_ATTRIBUTE_REP) > 0;
+    get<MAP_REP>(xed_tuple) = is_rep;
+  } else {
+    if(warn_not_found_ > 0) {
+      warn_not_found_ -= 1;
+      if(warn_not_found_ > 0) {
+        warn("No information for instruction at address 0x%lx", _vAddr);
+      } else {
+        warn("No information for instruction at address 0x%lx. "
+             "Suppressing further messages",
+             _vAddr);
+      }
+    }
+    // Replace the unknown instruction with a NOP
+    // NOTE: Unknown memory records are skipped, so 'rep' needs no special
+    // handling here
+    xed_map_.emplace(
+      _vAddr, make_tuple(0, true, false, false, makeNop(_reported_size)));
+  }
+}
+
+unique_ptr<xed_decoded_inst_t> TraceReader::makeNop(uint8_t _length) {
+  // A 10-to-15-byte NOP instruction (direct XED support is only up to 9)
+  static const char* nop15 =
+    "\x66\x66\x66\x66\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00";
+
+  auto                ptr = make_unique<xed_decoded_inst_t>();
+  xed_decoded_inst_t* ins = ptr.get();
+  xed_decoded_inst_zero_set_mode(ins, &xed_state_);
+  xed_error_enum_t res;
+
+  // The reported instruction length must be 1-15 bytes
+  _length &= 0xf;
+  assert(_length > 0);
+  if(_length > 9) {
+    int            offset = 15 - _length;
+    const uint8_t* pos    = reinterpret_cast<const uint8_t*>(nop15 + offset);
+    res                   = xed_decode(ins, pos, 15 - offset);
+  } else {
+    uint8_t buf[10];
+    res = xed_encode_nop(&buf[0], _length);
+    if(res != XED_ERROR_NONE) {
+      warn("XED NOP encode error: %s", xed_error_enum_t2str(res));
+    }
+    res = xed_decode(ins, buf, sizeof(buf));
+  }
+  if(res != XED_ERROR_NONE) {
+    warn("XED NOP decode error: %s", xed_error_enum_t2str(res));
+  }
+  return ptr;
+}
+
+void TraceReader::init_buffer() {
+  // Push one dummy entry so we can pop in nextInstruction()
+  ins_buffer.emplace_back(InstInfo());
+
+  for(uint32_t i = 0; i < buf_size_; i++) {
+    ins_buffer.emplace_back(*getNextInstruction());
+  }
+}
+
+const InstInfo* TraceReader::nextInstruction() {
+  ins_buffer.pop_front();
+  ins_buffer.emplace_back(*getNextInstruction());
+  return &ins_buffer.front();
+}
+
+// Find the next buffer entry, starting from ref, that matches the given PC
+const TraceReader::returnValue TraceReader::findPC(bufferEntry& ref,
+                                                   uint64_t     _pc) {
+  for(; ref != ins_buffer.end(); ref++) {
+    if(ref->pc == _pc) {
+      return ENTRY_VALID;
+    }
+  }
+  return ENTRY_NOT_FOUND;
+}
+
+const TraceReader::returnValue TraceReader::peekInstructionAtIndex(
+  uint32_t idx, bufferEntry& ref) {
+  if(idx >= ins_buffer.size())
+    return ENTRY_NOT_FOUND;
+
+  ref = ins_buffer.begin();
+  for(; ref != ins_buffer.end(); ref++) {
+    if(idx == 0)
+      break;
+    idx--;
+  }
+  return ENTRY_VALID;
+}
+
+const TraceReader::returnValue TraceReader::findPCInSegment(
+  bufferEntry& ref, uint64_t _pc, uint64_t _termination_pc) {
+  if(ref == ins_buffer.end())
+    return ENTRY_NOT_FOUND;
+
+  for(ref++; ref != ins_buffer.end(); ref++) {
+    if(ref->pc == _pc) {
+      return ENTRY_VALID;
+    } else if(ref->pc == _termination_pc) {
+      return ENTRY_OUT_OF_SEGMENT;
+    }
+  }
+  return ENTRY_NOT_FOUND;
+}
+
+TraceReader::bufferEntry TraceReader::bufferStart() {
+  return ins_buffer.begin();
+}

--- a/src/frontend/memtrace/memtrace_trace_reader.h
+++ b/src/frontend/memtrace/memtrace_trace_reader.h
@@ -1,0 +1,130 @@
+/* Copyright 2020 University of California Santa Cruz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/***************************************************************************************
+ * File         : frontend/memtrace_trace_reader.h
+ * Author       : Heiner Litz
+ * Date         : 05/15/2020
+ * Description  :
+ ***************************************************************************************/
+#ifndef MEMTRACE_TRACE_READER_H
+#define MEMTRACE_TRACE_READER_H
+
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#define DR_DO_NOT_DEFINE_int64
+#include "./pin/pin_lib/x86_decoder.h"
+
+extern "C" {
+#include "xed-interface.h"
+}
+
+#if __cplusplus < 201402L
+template <typename T, typename... Args>
+static std::unique_ptr<T> make_unique(Args&&... args) {
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+#else
+using std::make_unique;
+#endif
+
+// Indices to 'xed_map_' cached features
+static constexpr int MAP_MEMOPS  = 0;
+static constexpr int MAP_UNKNOWN = 1;
+static constexpr int MAP_COND    = 2;
+static constexpr int MAP_REP     = 3;
+static constexpr int MAP_XED     = 4;
+
+class TraceReader {
+ public:
+  enum returnValue : uint8_t {
+    ENTRY_VALID,
+    ENTRY_NOT_FOUND,
+    ENTRY_FIRST,
+    ENTRY_OUT_OF_SEGMENT,
+  };
+  using bufferEntry = std::deque<InstInfo>::iterator;
+
+  // The default-constructed object will not return valid instructions
+  TraceReader();
+  // A trace and single-binary object
+  TraceReader(const std::string& _trace, const std::string& _binary,
+              uint64_t _offset, uint32_t _buf_size = 0);
+  // A trace and multi-binary object which reads 'binary-info.txt' from the
+  // input path. This file contains one '<binary> <offset>' pair per line.
+  TraceReader(const std::string& _trace, const std::string& _binary_group_path,
+              uint32_t _buf_size = 0);
+  ~TraceReader();
+  // A constructor that fails will cause operator! to return true
+  bool              operator!();
+  const InstInfo*   nextInstruction();
+  const returnValue findPCInSegment(bufferEntry& ref, uint64_t _pc,
+                                    uint64_t _termination_pc);
+  const returnValue findPC(bufferEntry& ref, uint64_t _pc);
+  const returnValue peekInstructionAtIndex(uint32_t idx, bufferEntry& ref);
+  bufferEntry       bufferStart();
+
+ private:
+  virtual const InstInfo* getNextInstruction()                        = 0;
+  virtual void            binaryGroupPathIs(const std::string& _path) = 0;
+  virtual bool            initTrace()                                 = 0;
+  virtual bool            locationForVAddr(uint64_t _vaddr, uint8_t** _loc,
+                                           uint64_t* _size)           = 0;
+
+  void init_buffer();
+  void binaryFileIs(const std::string& _binary, uint64_t _offset);
+
+  std::unique_ptr<xed_decoded_inst_t> makeNop(uint8_t _length);
+
+ protected:
+  std::string                                                    trace_;
+  InstInfo                                                       info_;
+  InstInfo                                                       invalid_info_;
+  bool                                                           trace_ready_;
+  bool                                                           binary_ready_;
+  xed_state_t                                                    xed_state_;
+  std::unordered_map<std::string, std::pair<uint8_t*, uint64_t>> binaries_;
+  std::vector<std::tuple<uint64_t, uint64_t, uint8_t*>>          sections_;
+  std::unordered_map<uint64_t, std::tuple<int, bool, bool, bool,
+                                          std::unique_ptr<xed_decoded_inst_t>>>
+                       xed_map_;
+  int                  warn_not_found_;
+  uint64_t             skipped_;
+  uint32_t             buf_size_;
+  std::deque<InstInfo> ins_buffer;
+
+  void init(const std::string& _trace);
+  bool initBinary(const std::string& _name, uint64_t _offset);
+  void clearBinaries();
+  void fillCache(uint64_t _vAddr, uint8_t _reported_size,
+                 uint8_t* inst_bytes = NULL);
+  void traceFileIs(const std::string& _trace);
+};
+
+#endif

--- a/src/frontend/memtrace/memtrace_trace_reader_memtrace.cc
+++ b/src/frontend/memtrace/memtrace_trace_reader_memtrace.cc
@@ -1,0 +1,343 @@
+/* Copyright 2020 University of California Santa Cruz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/***************************************************************************************
+ * File         : frontend/memtrace_trace_reader_memtrace.h
+ * Author       : Heiner Litz
+ * Date         : 05/15/2020
+ * Description  :
+ ***************************************************************************************/
+
+#include "frontend/memtrace/memtrace_trace_reader_memtrace.h"
+
+#include "elf.h"
+
+#define warn(...) printf(__VA_ARGS__)
+#define panic(...) printf(__VA_ARGS__)
+
+// Trace + single binary
+TraceReaderMemtrace::TraceReaderMemtrace(const std::string& _trace,
+                                         const std::string& _binary,
+                                         uint64_t _offset, uint32_t _bufsize) :
+    TraceReader(_trace, _binary, _offset, _bufsize),
+    mt_iter_(nullptr), mt_end_(nullptr), mt_state_(MTState::INST),
+    mt_mem_ops_(0), mt_seq_(0), mt_prior_isize_(0), mt_using_info_a_(true),
+    mt_warn_target_(0) {
+  init(_trace);
+}
+
+// Trace + multiple binaries
+TraceReaderMemtrace::TraceReaderMemtrace(const std::string& _trace,
+                                         const std::string& _binary_group_path,
+                                         uint32_t           _bufsize) :
+    TraceReader(_trace, _binary_group_path, _bufsize),
+    mt_iter_(nullptr), mt_end_(nullptr), mt_state_(MTState::INST),
+    mt_mem_ops_(0), mt_seq_(0), mt_prior_isize_(0), mt_using_info_a_(true),
+    mt_warn_target_(0) {
+  binaryGroupPathIs(_binary_group_path);
+  init(_trace);
+}
+
+TraceReaderMemtrace::~TraceReaderMemtrace() {
+  if(mt_warn_target_ > 0) {
+    warn("Set %lu conditional branches to 'not-taken' due to pid/tid gaps\n",
+         mt_warn_target_);
+  }
+}
+
+void TraceReaderMemtrace::init(const std::string& _trace) {
+  mt_info_a_.custom_op = CustomOp::NONE;
+  mt_info_b_.custom_op = CustomOp::NONE;
+  mt_info_a_.valid     = true;
+  mt_info_b_.valid     = true;
+  TraceReader::init(_trace);
+}
+
+// TODO: Detect memtrace/module.log type dynamically
+#ifdef ZSIM_USE_YT
+/* Below is required to parse Google Memtraces that contain an extra column */
+const char* TraceReaderMemtrace::parse_buildid_string(const char* src,
+                                                      OUT void**  data) {
+  // We just skip the string.  We don't store it as we're not using it here.
+  const char* comma = strchr(src, ',');
+  if(comma == nullptr)
+    return nullptr;
+  return comma + 1;
+}
+#endif
+
+void TraceReaderMemtrace::binaryGroupPathIs(const std::string& _path) {
+  clearBinaries();
+  binary_ready_ = true;  // An absent binary is allowed
+  if(!_path.empty()) {
+    std::string info_name;
+    info_name = _path + "/modules.log";
+    std::ifstream info_file(info_name);
+    if(!info_file.is_open()) {
+      panic("Could not open binary collection info file '%s': %s",
+            info_name.c_str(), strerror(errno));
+    }
+    if(_path.empty()) {
+      panic("Module file path is missing");
+      return;
+    }
+    dcontext_         = dr_standalone_init();
+    std::string error = directory_.initialize_module_file(_path +
+                                                          "/modules.log");
+    if(!error.empty()) {
+      panic("Failed to initialize directory: %s Cannot find a file named "
+            "modules.log",
+            error.c_str());
+      return;
+    }
+    module_mapper_ = module_mapper_t::create(directory_.modfile_bytes_,
+#ifdef ZSIM_USE_YT
+                                             parse_buildid_string,
+#else
+                                             nullptr,
+#endif
+                                             nullptr, nullptr, nullptr,
+                                             knob_verbose_);
+    module_mapper_->get_loaded_modules();
+    error = module_mapper_->get_last_error();
+    if(!error.empty()) {
+      panic("Failed to load binaries: %s Check that module.log references the "
+            "correct binary paths.",
+            error.c_str());
+      return;
+    }
+    binary_ready_ = true;
+  }
+}
+
+bool TraceReaderMemtrace::initTrace() {
+  mt_reader_ = make_unique<analyzer_t>(trace_);
+  if(!(*mt_reader_)) {
+    panic("Failure starting memtrace reader");
+    return false;
+  }
+  mt_iter_ = &(mt_reader_->begin());
+  mt_end_  = &(mt_reader_->end());
+
+  // Set info 'A' to the first complete instruction.
+  // It will initially lack branch target information.
+  getNextInstruction__(&mt_info_a_, &mt_info_b_);
+  mt_using_info_a_ = false;
+  return true;
+}
+
+bool TraceReaderMemtrace::getNextInstruction__(InstInfo* _info,
+                                               InstInfo* _prior) {
+  uint32_t prior_isize = mt_prior_isize_;
+  bool     complete    = false;
+
+  while(*mt_iter_ != *mt_end_) {
+    switch(mt_state_) {
+      case(MTState::INST):
+        mt_ref_ = **mt_iter_;
+        if(type_is_instr(mt_ref_.instr.type)) {
+          processInst(_info);
+          if(mt_mem_ops_ > 0) {
+            mt_state_ = MTState::MEM1;
+          } else {
+            complete = true;
+          }
+        } else if(typeIsMem(mt_ref_.data.type)) {
+          // Skip flush and thread exit types, patch rep instructions, and
+          // silently ignore memory operands of unknown instructions
+          if(!_prior->unknown_type) {
+            bool is_rep = std::get<MAP_REP>(xed_map_.at(_prior->pc));
+            if(is_rep && ((uint32_t)mt_ref_.data.pid == _prior->pid) &&
+               ((uint32_t)mt_ref_.data.tid == _prior->tid) &&
+               (mt_ref_.data.pc == _prior->pc)) {
+              *_info             = *_prior;
+              _info->mem_addr[0] = mt_ref_.data.addr;
+              _info->mem_used[0] = true;
+              if(mt_mem_ops_ > 1) {
+                mt_state_ = MTState::MEM2;
+              } else {
+                _info->mem_addr[1] = 0;
+                _info->mem_used[1] = false;
+                complete           = true;
+              }
+            } else {
+              if(skipped_ == 0) {
+                warn("Stray memory record detected at seq. %lu: PC: 0x%lx, "
+                     "PID: %lu, TID: %lu, Addr: 0x%lx. "
+                     "Suppressing further messages.\n",
+                     mt_seq_, mt_ref_.data.pc, mt_ref_.data.pid,
+                     mt_ref_.data.tid, mt_ref_.data.addr);
+              }
+              skipped_++;
+            }
+          }
+        }
+        break;
+      case(MTState::MEM1):
+        mt_ref_ = **mt_iter_;
+        if(typeIsMem(mt_ref_.data.type)) {
+          if(((uint32_t)_info->pid == mt_ref_.data.pid) &&
+             ((uint32_t)_info->tid == mt_ref_.data.tid) &&
+             (_info->pc == mt_ref_.data.pc)) {
+            _info->mem_addr[0] = mt_ref_.data.addr;
+            _info->mem_used[0] = true;
+            if(mt_mem_ops_ > 1) {
+              mt_state_ = MTState::MEM2;
+            } else {
+              mt_state_ = MTState::INST;
+              complete  = true;
+            }
+          } else {
+            warn("Unexpected PID/TID/PC switch following 0x%lx\n", _info->pc);
+            mt_state_ = MTState::INST;
+          }
+        } else if(type_is_instr(mt_ref_.instr.type)) {
+          // REP Instructions with REP count 0
+          warn("REP BUG: Data size does not match instruction 0x%lx - PATCHING "
+               "size, success!\n",
+               _info->pc);
+
+          mt_state_ = MTState::INST;
+          complete  = true;
+          goto PATCH_REP;
+        } else {
+          warn("Expected data but found type '%s'\n",
+               trace_type_names[mt_ref_.data.type]);
+          mt_state_ = MTState::INST;
+        }
+        break;
+      case(MTState::MEM2):
+        mt_ref_ = **mt_iter_;
+        if(typeIsMem(mt_ref_.data.type)) {
+          if(((uint32_t)_info->pid == mt_ref_.data.pid) &&
+             ((uint32_t)_info->tid == mt_ref_.data.tid) &&
+             (_info->pc == mt_ref_.data.pc)) {
+            _info->mem_addr[1] = mt_ref_.data.addr;
+            _info->mem_used[1] = true;
+            assert(mt_mem_ops_ <= 2);
+            mt_state_ = MTState::INST;
+            complete  = true;
+          } else {
+            warn("Unexpected PID/TID/PC switch following 0x%lx\n", _info->pc);
+            mt_state_ = MTState::INST;
+          }
+        } else {
+          warn("Expected data2 but found type '%s'\n",
+               trace_type_names[mt_ref_.data.type]);
+          mt_state_ = MTState::INST;
+        }
+        break;
+    }
+    mt_seq_++;
+    ++(*mt_iter_);
+    if(complete) {
+      break;
+    }
+  }
+PATCH_REP:
+  // Compute the branch target information for the prior instruction
+  _prior->target = _info->pc;  // TODO(granta): Invalid for pid/tid switch
+  if(_prior->taken) {          // currently set iif conditional branch
+    bool non_seq = _info->pc != (_prior->pc + prior_isize);
+    bool new_gid = (_prior->tid != _info->tid) || (_prior->pid != _info->pid);
+    if(new_gid) {
+      // TODO(granta): If there are enough of these, it may make sense to
+      // delay conditional branch instructions until the thread resumes even
+      // though this alters the apparent order of the trace.
+      // (Seeking ahead to resolve the branch info is a non-starter.)
+      if(mt_warn_target_ == 0) {
+        warn("Detected a conditional branch preceding a pid/tid change "
+             "at seq. %lu. Assuming not-taken. Suppressing further "
+             "messages.\n",
+             mt_seq_ - 1);
+      }
+      mt_warn_target_++;
+      non_seq = false;
+    }
+    _prior->taken = non_seq;
+  }
+
+  _info->valid &= complete;
+  return complete;
+}
+
+void TraceReaderMemtrace::processInst(InstInfo* _info) {
+  // Get the XED info from the cache, creating it if needed
+  auto xed_map_iter = xed_map_.find(mt_ref_.instr.addr);
+  if(xed_map_iter == xed_map_.end()) {
+    fillCache(mt_ref_.instr.addr, mt_ref_.instr.size);
+    xed_map_iter = xed_map_.find(mt_ref_.instr.addr);
+    assert((xed_map_iter != xed_map_.end()));
+  }
+  bool                unknown_type, cond_branch;
+  xed_decoded_inst_t* xed_ins;
+  auto&               xed_tuple = (*xed_map_iter).second;
+
+  tie(mt_mem_ops_, unknown_type, cond_branch, std::ignore,
+      std::ignore) = xed_tuple;
+  mt_prior_isize_  = mt_ref_.instr.size;
+  xed_ins          = std::get<MAP_XED>(xed_tuple).get();
+  _info->pc        = mt_ref_.instr.addr;
+  _info->ins       = xed_ins;
+  _info->pid       = mt_ref_.instr.pid;
+  _info->tid       = mt_ref_.instr.tid;
+  _info->target    = 0;        // Set when the next instruction is evaluated
+  _info->taken = cond_branch;  // Patched when the next instruction is evaluated
+  _info->mem_addr[0]  = 0;
+  _info->mem_addr[1]  = 0;
+  _info->mem_used[0]  = false;
+  _info->mem_used[1]  = false;
+  _info->unknown_type = unknown_type;
+}
+
+bool TraceReaderMemtrace::typeIsMem(trace_type_t _type) {
+  return ((_type == TRACE_TYPE_READ) || (_type == TRACE_TYPE_WRITE) ||
+          type_is_prefetch(_type));
+}
+
+const InstInfo* TraceReaderMemtrace::getNextInstruction() {
+  InstInfo& info   = (mt_using_info_a_ ? mt_info_a_ : mt_info_b_);
+  InstInfo& prior  = (mt_using_info_a_ ? mt_info_b_ : mt_info_a_);
+  mt_using_info_a_ = !mt_using_info_a_;
+  if(getNextInstruction__(&info, &prior)) {
+    return &prior;
+  } else {
+    return &invalid_info_;
+  }
+}
+
+bool TraceReaderMemtrace::locationForVAddr(uint64_t _vaddr, uint8_t** _loc,
+                                           uint64_t* _size) {
+  app_pc module_start;
+  size_t module_size;
+
+  *_loc = module_mapper_->find_mapped_trace_bounds(
+    reinterpret_cast<app_pc>(_vaddr), &module_start, &module_size);
+  *_size = reinterpret_cast<uint64_t>(module_size) -
+           (reinterpret_cast<uint64_t>(*_loc) -
+            reinterpret_cast<uint64_t>(module_start));
+  if(!module_mapper_->get_last_error().empty()) {
+    std::cout << "Failed to find mapped address: " << std::hex << _vaddr
+              << " Error: " << module_mapper_->get_last_error() << std::endl;
+    return false;
+  }
+  return true;
+}

--- a/src/frontend/memtrace/memtrace_trace_reader_memtrace.h
+++ b/src/frontend/memtrace/memtrace_trace_reader_memtrace.h
@@ -1,0 +1,83 @@
+/* Copyright 2020 University of California Santa Cruz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/***************************************************************************************
+ * File         : frontend/memtrace_trace_reader_memtrace.h
+ * Author       : Heiner Litz
+ * Date         : 05/15/2020
+ * Description  :
+ ***************************************************************************************/
+#ifndef MEMTRACE_READER_MEMTRACE_H
+#define MEMTRACE_READER_MEMTRACE_H
+
+#include "frontend/memtrace/memtrace_trace_reader.h"
+
+//#include "instrument.h"
+#include "analyzer.h"
+#include "raw2trace.h"
+#include "raw2trace_directory.h"
+
+class TraceReaderMemtrace : public TraceReader {
+ public:
+  const InstInfo* getNextInstruction() override;
+  TraceReaderMemtrace(const std::string& _trace, const std::string& _binary,
+                      uint64_t _offset, uint32_t _bufsize);
+  TraceReaderMemtrace(const std::string& _trace,
+                      const std::string& _binary_group_path, uint32_t _bufsize);
+  ~TraceReaderMemtrace();
+
+ private:
+  void               binaryGroupPathIs(const std::string& _path) override;
+  bool               initTrace() override;
+  bool               locationForVAddr(uint64_t _vaddr, uint8_t** _loc,
+                                      uint64_t* _size) override;
+  void               init(const std::string& _trace);
+  static const char* parse_buildid_string(const char* src, OUT void** data);
+  bool               getNextInstruction__(InstInfo* _info, InstInfo* _prior);
+  void               processInst(InstInfo* _info);
+  bool               typeIsMem(trace_type_t _type);
+
+  std::unique_ptr<module_mapper_t> module_mapper_;
+  raw2trace_directory_t            directory_;
+  void*                            dcontext_;
+  unsigned int                     knob_verbose_;
+
+  enum class MTState {
+    INST,
+    MEM1,
+    MEM2,
+  };
+
+  std::unique_ptr<analyzer_t> mt_reader_;
+  reader_t*                   mt_iter_;
+  reader_t*                   mt_end_;
+  MTState                     mt_state_;
+  memref_t                    mt_ref_;
+  int                         mt_mem_ops_;
+  uint64_t                    mt_seq_;
+  uint32_t                    mt_prior_isize_;
+  InstInfo                    mt_info_a_;
+  InstInfo                    mt_info_b_;
+  bool                        mt_using_info_a_;
+  uint64_t                    mt_warn_target_;
+};
+
+#endif

--- a/src/general.param.def
+++ b/src/general.param.def
@@ -60,6 +60,7 @@ DEF_PARAM( forward_progress_interval    , FORWARD_PROGRESS_INTERVAL , uns    , u
 /* Fast forward in Instructions */                                                         
 DEF_PARAM( fast_forward                 , FAST_FORWARD              , uns64    , uns64   , 0        ,       )
 DEF_PARAM( fast_forward_until_addr      , FAST_FORWARD_UNTIL_ADDR   , uns      , uns     , 0        ,       )
+DEF_PARAM( fast_forward_trace_ins       , FAST_FORWARD_TRACE_INS    , uns64    , uns64   , 0        ,       )
 DEF_PARAM( warmup                       , WARMUP                    , uns64    , uns64   , 0        ,       )
 
 DEF_PARAM( heartbeat_interval           , HEARTBEAT_INTERVAL        , uns    , uns       , 1000000  ,       ) 

--- a/utils/memtrace/portabilize_trace.py
+++ b/utils/memtrace/portabilize_trace.py
@@ -1,0 +1,64 @@
+# Portabilize trace by copying binary dependencies to a local directory
+# Usage: python portabilize_trace.py [trace directory, e.g. ~/drmemtrace.trace1.1234.2134.dir/]
+#
+
+from shutil import copy
+from os import mkdir
+from os import path
+import sys
+
+
+if len(sys.argv) < 2:
+    print('Usage: python portabilize_trace.py [trace directory, e.g. ~/drmemtrace.trace1.1234.2134.dir/]')
+    exit();
+
+traceDir = sys.argv[1]
+
+binPath = traceDir + '/bin/'
+if not path.exists(binPath):
+    mkdir(binPath)
+
+data = []
+with open(traceDir + '/bin/modules.log', 'r') as infile :
+    separator = ', '
+    first = 1
+    col = 99
+    for line in infile:
+        s = line.split(separator)
+        if first:
+            ss = s[0].split(' ')
+            
+            first = 0
+            if ss[2] != 'version':
+                print('Corrupt file format'+s[2])
+                exit()
+            else:
+                #version == 5
+                if ss[3] == '5':
+                    col = 8
+                #earlier versions
+                elif ss[3] < 5:
+                    col = 7
+                else:
+                    print('new file format, please add support')
+                    exit()
+                    
+# Skip over but preserve lines that don't describe libraries
+        if len(s) < col+1 or s[col][0] != '/':
+            data.append(line);
+            continue;
+        libPath = s[col].strip()
+        copy(libPath, binPath)
+        # Modify the path to the library to point to new, relative path
+        libName = path.basename(libPath)
+        newLibPath = path.abspath(binPath + libName)
+        s[col] = newLibPath + '\n'
+        
+        data.append(separator.join(s))
+
+with open(traceDir + '/raw/modules.log', 'w') as outfile:
+    for wline in data:
+        outfile.write(wline)
+
+
+

--- a/utils/memtrace/run_portabilize_trace.sh
+++ b/utils/memtrace/run_portabilize_trace.sh
@@ -1,0 +1,15 @@
+SCRIPT=$(readlink -f "$0")
+SCRIPTDIR=$(dirname "$SCRIPT")
+
+DRIO_BUILD_DIR=${SCRIPTDIR}/../../src/build/opt/deps/dynamorio
+
+for dir in */; do
+    echo "$dir"
+    cd $dir
+    mkdir -p bin
+    cp raw/modules.log bin/modules.log
+    python2 $SCRIPTDIR/portabilize_trace.py .
+    cp bin/modules.log raw/modules.log
+    ${DRIO_BUILD_DIR}/clients/bin64/drraw2trace -indir ./raw/ &
+    cd -
+done

--- a/utils/memtrace/run_update_trace.sh
+++ b/utils/memtrace/run_update_trace.sh
@@ -1,0 +1,11 @@
+SCRIPT=$(readlink -f "$0")
+SCRIPTDIR=$(dirname "$SCRIPT")
+
+DRIO_BUILD_DIR=${SCRIPTDIR}/../../src/build/opt/deps/dynamorio
+
+for dir in */; do
+    echo "$dir"
+    cd $dir
+    python2 $SCRIPTDIR/updateTraceModulePaths.py .
+    cd -
+done

--- a/utils/memtrace/updateTraceModulePaths.py
+++ b/utils/memtrace/updateTraceModulePaths.py
@@ -1,0 +1,67 @@
+# Update paths in modules.log to the new absolute paths.
+# Required step whenever trace is moved to a new location.
+# Usage: python updateTraceModulePaths.py [trace directory, e.g. ~/drmemtrace.trace1.1234.2134.dir/]
+#
+
+from os import mkdir
+from os import path
+import sys
+
+print (len(sys.argv))
+
+if len(sys.argv) < 2:
+    print ('Usage: python updateTraceModulePaths.py [trace directory, e.g. ~/drmemtrace.trace1.1234.2134.dir/]')
+    exit();
+
+traceDir = sys.argv[1]
+
+binPath = traceDir + '/bin/'
+if not path.exists(binPath):
+    print ('Error: first portabilize trace')
+    exit();
+
+
+    
+data = []
+with open(traceDir + '/bin/modules.log', 'r') as infile:
+    separator = ', '
+    first = 1
+    col = 99
+    for line in infile:
+        s = line.split(separator)
+        if first:
+            ss = s[0].split(' ')
+            
+            first = 0
+            if ss[2] != 'version':
+                print('Corrupt file format'+s[2])
+                exit()
+            else:
+                #version == 5
+                if ss[3] == '5':
+                    col = 8
+                #earlier versions
+                elif ss[3] < 5:
+                    col = 7
+                else:
+                    print('new file format, please add support')
+                    exit()
+
+        # Skip over but preserve lines that don't describe libraries
+        if len(s) < col+1 or s[col][0] != '/':
+            data.append(line);
+            continue;
+        libPath = s[col].strip()
+        # Modify the path to the library to point to new, relative path
+        libName = path.basename(libPath)
+        newLibPath = path.abspath(traceDir + '/bin/' + libName)
+        s[col] = newLibPath + '\n'
+
+        print (s)
+        
+        data.append(separator.join(s))
+    
+with open(traceDir + '/bin/modules.log', 'w') as outfile:
+    for wline in data:
+        outfile.write(wline)
+


### PR DESCRIPTION
To simulate a memtrace, set the following scarab parameters:
--frontend memtrace --fetch_off_path_ops 0
--cbp_trace_r0=<PATH_TO_GZIPPED_TRACE>
--memtrace_modules_log=<PATH_TO_MODULES_LOG_FILE>

Compilation of the memtrace frontend is disabled by default and can
be enbled by setting the environment variable ENABLE_MEMTRACE=1
passed to make or defined globaly.

Dynamorio is added as a new dependency via a git submodule.
Dynamorio introduces the following new dependencies:
snappy, dl, config++, z, rt, pthread