### PR TITLE
add an option to exit sim when the first workload finishes

### DIFF
--- a/src/general.param.def
+++ b/src/general.param.def
@@ -96,3 +96,5 @@ DEF_PARAM( use_unsure_free_lists        , USE_UNSURE_FREE_LISTS     , Flag   , F
 
 DEF_PARAM( optimizer2_max_num_slaves    , OPTIMIZER2_MAX_NUM_SLAVES , uns    , uns       , 64       ,       )
 DEF_PARAM( optimizer2_perfect_memoryless, OPTIMIZER2_PERFECT_MEMORYLESS, Flag, Flag      , FALSE    ,       )
+
+DEF_PARAM( exit_cond                    , EXIT_COND                 , uns    , exit_cond , 0        ,       )

--- a/src/general.param.def
+++ b/src/general.param.def
@@ -97,4 +97,4 @@ DEF_PARAM( use_unsure_free_lists        , USE_UNSURE_FREE_LISTS     , Flag   , F
 DEF_PARAM( optimizer2_max_num_slaves    , OPTIMIZER2_MAX_NUM_SLAVES , uns    , uns       , 64       ,       )
 DEF_PARAM( optimizer2_perfect_memoryless, OPTIMIZER2_PERFECT_MEMORYLESS, Flag, Flag      , FALSE    ,       )
 
-DEF_PARAM( exit_cond                    , EXIT_COND                 , uns    , exit_cond , 0        ,       )
+DEF_PARAM( exit_cond                    , EXIT_COND                 , int    , exit_cond , 0        ,       )

--- a/src/param_parser.c
+++ b/src/param_parser.c
@@ -79,6 +79,7 @@ the program.  This way, an exact duplicate run can be performed.
 const char* help_options[]   = {"-help", "-h", "--help",
                               "--h"}; /* cmd-line help options strings */
 const char* sim_mode_names[] = {"uop", "full"};
+const char* exit_cond[]      = {"last_done", "first_done"};
 
 /**************************************************************************************/
 /* include all header files with enum declarations used as parameters */
@@ -278,6 +279,24 @@ void get_sim_mode_param(const char* name, Generic_Enum* variable) {
     FATAL_ERROR(0, "Parameter '%s' missing value --- Ignored.\n", name);
 }
 
+/**************************************************************************************/
+/* get_exit_cond: match input string to internal enum
+ */
+
+void get_exit_cond_param(const char* name, Generic_Enum* variable) {
+  if(optarg) {
+    uns ii;
+
+    for(ii = 0; ii < NUM_EXIT_CONDS; ii++)
+      if(strncmp(optarg, exit_cond[ii], MAX_STR_LENGTH) == 0) {
+        *variable = ii;
+        return;
+      }
+    FATAL_ERROR(0, "Invalid value ('%s') for parameter '%s' --- Ignored.\n",
+                optarg, name);
+  } else
+    FATAL_ERROR(0, "Parameter '%s' missing value --- Ignored.\n", name);
+}
 
 /**************************************************************************************/
 /* get_sim_model: Converts the optarg string to a number by looking it up in the

--- a/src/param_parser.c
+++ b/src/param_parser.c
@@ -76,10 +76,10 @@ the program.  This way, an exact duplicate run can be performed.
 /**************************************************************************************/
 /* Global Variables */
 
-const char* help_options[]   = {"-help", "-h", "--help",
+const char* help_options[]    = {"-help", "-h", "--help",
                               "--h"}; /* cmd-line help options strings */
-const char* sim_mode_names[] = {"uop", "full"};
-const char* exit_cond[]      = {"last_done", "first_done"};
+const char* sim_mode_names[]  = {"uop", "full"};
+const char* exit_cond_names[] = {"last_done", "first_done"};
 
 /**************************************************************************************/
 /* include all header files with enum declarations used as parameters */
@@ -288,7 +288,7 @@ void get_exit_cond_param(const char* name, Generic_Enum* variable) {
     uns ii;
 
     for(ii = 0; ii < NUM_EXIT_CONDS; ii++)
-      if(strncmp(optarg, exit_cond[ii], MAX_STR_LENGTH) == 0) {
+      if(strncmp(optarg, exit_cond_names[ii], MAX_STR_LENGTH) == 0) {
         *variable = ii;
         return;
       }

--- a/src/param_parser.h
+++ b/src/param_parser.h
@@ -45,6 +45,7 @@ void   get_btb_mech_param(const char*, uns*);
 void   get_ibtb_mech_param(const char*, uns*);
 void   get_conf_mech_param(const char*, uns*);
 void   get_sim_mode_param(const char*, Generic_Enum*);
+void   get_exit_cond_param(const char*, Generic_Enum*);
 void   get_sim_model_param(const char*, uns*);
 void   get_frontend_param(const char*, uns*);
 // void get_dram_sched_param(const char *, uns *); // Ramulator_remove

--- a/src/sim.c
+++ b/src/sim.c
@@ -614,6 +614,7 @@ void uop_sim() {
 void full_sim() {
   uns8 proc_id;
   Flag all_sim_done = FALSE;
+  Flag sim_process_finished = FALSE;
 
   /* perform initialization  */
   init_model(WARMUP_MODE);  // make sure this happens before init_op_pool
@@ -651,7 +652,12 @@ void full_sim() {
   clear_stats = trigger_create("CLEAR_STATS", CLEAR_STATS, TRIGGER_ONCE);
 
   /* main loop */
-  while(!trigger_fired(sim_limit) && !all_sim_done) {
+  while(!trigger_fired(sim_limit)) {
+    //sim control
+    if(all_sim_done) break;
+    else if(EXIT_COND == FIRST_DONE){
+      if(sim_process_finished) break;
+    }
     freq_advance_time();
     sim_time = freq_time();
     model->cycle_func();
@@ -675,6 +681,7 @@ void full_sim() {
     }
 
     all_sim_done = TRUE;
+    sim_process_finished = FALSE;
     for(proc_id = 0; proc_id < NUM_CORES; proc_id++) {
       Flag reachedInstLimit = (INST_LIMIT &&
                                inst_count[proc_id] >= inst_limit[proc_id]);
@@ -685,6 +692,7 @@ void full_sim() {
           model->per_core_done_func(proc_id);
         dump_stats(proc_id, TRUE, global_stat_array[proc_id], NUM_GLOBAL_STATS);
         sim_done[proc_id] = TRUE;
+        sim_process_finished = TRUE;
         check_heartbeat(proc_id, TRUE);
 
         if(retired_exit[proc_id] && FRONTEND == FE_TRACE) {

--- a/src/sim.c
+++ b/src/sim.c
@@ -613,7 +613,7 @@ void uop_sim() {
 
 void full_sim() {
   uns8 proc_id;
-  Flag all_sim_done = FALSE;
+  Flag all_sim_done         = FALSE;
   Flag sim_process_finished = FALSE;
 
   /* perform initialization  */
@@ -653,10 +653,12 @@ void full_sim() {
 
   /* main loop */
   while(!trigger_fired(sim_limit)) {
-    //sim control
-    if(all_sim_done) break;
-    else if(EXIT_COND == FIRST_DONE){
-      if(sim_process_finished) break;
+    // sim control
+    if(all_sim_done)
+      break;
+    else if(EXIT_COND == FIRST_DONE) {
+      if(sim_process_finished)
+        break;
     }
     freq_advance_time();
     sim_time = freq_time();
@@ -680,7 +682,7 @@ void full_sim() {
       reset_stats(TRUE);
     }
 
-    all_sim_done = TRUE;
+    all_sim_done         = TRUE;
     sim_process_finished = FALSE;
     for(proc_id = 0; proc_id < NUM_CORES; proc_id++) {
       Flag reachedInstLimit = (INST_LIMIT &&
@@ -691,7 +693,7 @@ void full_sim() {
         if(model->per_core_done_func)
           model->per_core_done_func(proc_id);
         dump_stats(proc_id, TRUE, global_stat_array[proc_id], NUM_GLOBAL_STATS);
-        sim_done[proc_id] = TRUE;
+        sim_done[proc_id]    = TRUE;
         sim_process_finished = TRUE;
         check_heartbeat(proc_id, TRUE);
 

--- a/src/sim.h
+++ b/src/sim.h
@@ -39,7 +39,7 @@ enum operating_mode_enum {
   WARMUP_MODE /* not implemented yet */
 };
 
-enum exit_cond_enum {LAST_DONE, FIRST_DONE, NUM_EXIT_COND};
+enum exit_cond_enum { LAST_DONE, FIRST_DONE, NUM_EXIT_CONDS };
 
 /**************************************************************************************/
 /* External Variables */

--- a/src/sim.h
+++ b/src/sim.h
@@ -39,6 +39,8 @@ enum operating_mode_enum {
   WARMUP_MODE /* not implemented yet */
 };
 
+enum exit_cond_enum {LAST_DONE, FIRST_DONE, NUM_EXIT_COND};
+
 /**************************************************************************************/
 /* External Variables */
 


### PR DESCRIPTION
A little bit unsure about whether this is done in a correct way. With this patch the run file accept something like `--exit_cond <first_done|last_done>` but won't accept `--exit_cond <0|1>`. Even though the default for this config is defined as `0` (last_done) in the `general.param.def` file.