### PR TITLE
Set oracle_info.dir to TAKEN for unconditional branches.

### DIFF
--- a/src/frontend/memtrace/memtrace_trace_reader_memtrace.cc
+++ b/src/frontend/memtrace/memtrace_trace_reader_memtrace.cc
@@ -255,7 +255,7 @@ bool TraceReaderMemtrace::getNextInstruction__(InstInfo* _info,
 PATCH_REP:
   // Compute the branch target information for the prior instruction
   _prior->target = _info->pc;  // TODO(granta): Invalid for pid/tid switch
-  if(_prior->taken) {          // currently set iif conditional branch
+  if (_prior->taken) {  // currently set iif branch
     bool non_seq = _info->pc != (_prior->pc + prior_isize);
     bool new_gid = (_prior->tid != _info->tid) || (_prior->pid != _info->pid);
     if(new_gid) {
@@ -300,7 +300,11 @@ void TraceReaderMemtrace::processInst(InstInfo* _info) {
   _info->pid       = mt_ref_.instr.pid;
   _info->tid       = mt_ref_.instr.tid;
   _info->target    = 0;        // Set when the next instruction is evaluated
-  _info->taken = cond_branch;  // Patched when the next instruction is evaluated
+  // Set as taken if it's a branch.
+  // Conditional branches are patched when the next instruction is evaluated.
+  _info->taken = category == XED_CATEGORY_UNCOND_BR ||
+                 category == XED_CATEGORY_COND_BR ||
+                 category == XED_CATEGORY_CALL;
   _info->mem_addr[0]  = 0;
   _info->mem_addr[1]  = 0;
   _info->mem_used[0]  = false;


### PR DESCRIPTION
Previously unconditional branches were set to NOT_TAKEN in the memtrace frontend. One way this error manifested is that with PERFECT_BP the branch predicted NOT_TAKEN although the next instruction was not PC plus offset. This was treated as a misfetch, leading to substantial stalls.